### PR TITLE
MetadataMap checked for parent classes

### DIFF
--- a/src/ZF/Hal/Metadata/MetadataMap.php
+++ b/src/ZF/Hal/Metadata/MetadataMap.php
@@ -104,9 +104,20 @@ class MetadataMap
     public function has($class)
     {
         if (is_object($class)) {
-            $class = get_class($class);
+            $className = get_class($class);
+        } else {
+            $className = $class;
         }
-        return array_key_exists($class, $this->map);
+
+        if (array_key_exists($className, $this->map)) {
+            return true;
+        }
+
+        if (get_parent_class($className)) {
+            return $this->has(get_parent_class($className));
+        }
+
+        return false;
     }
 
     /**
@@ -118,8 +129,19 @@ class MetadataMap
     public function get($class)
     {
         if (is_object($class)) {
-            $class = get_class($class);
+            $className = get_class($class);
+        } else {
+            $className = $class;
         }
-        return $this->map[$class];
+
+        if (isset($this->map[$className])) {
+            return $this->map[$className];
+        }
+
+        if (get_parent_class($className)) {
+            return $this->get(get_parent_class($className));
+        }
+
+        return false;
     }
 }

--- a/test/ZFTest/Hal/Plugin/TestAsset/EmbeddedProxyResource.php
+++ b/test/ZFTest/Hal/Plugin/TestAsset/EmbeddedProxyResource.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2013 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Hal\Plugin\TestAsset;
+
+class EmbeddedProxyResource extends EmbeddedResource
+{
+    public $id;
+    public $name;
+
+    public function __construct($id, $name)
+    {
+        $this->id   = $id;
+        $this->name = $name;
+    }
+}

--- a/test/ZFTest/Hal/Plugin/TestAsset/EmbeddedProxyResourceWithCustomIdentifier.php
+++ b/test/ZFTest/Hal/Plugin/TestAsset/EmbeddedProxyResourceWithCustomIdentifier.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2013 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Hal\Plugin\TestAsset;
+
+class EmbeddedProxyResourceWithCustomIdentifier extends EmbeddedResourceWithCustomIdentifier
+{
+    public $custom_id;
+    public $name;
+
+    public function __construct($id, $name)
+    {
+        $this->custom_id = $id;
+        $this->name      = $name;
+    }
+}


### PR DESCRIPTION
When proxy classes are substituted for mapped entities in Doctrine the resources are not rendered properly.  

This PR adds parent class checking of metadata mapping information.  I think this can reach further than the Proxy use case such as a common logging resource with extended resources for Doctrine inheritance.
