### PR TITLE
Don't overwrite the self link it it's already set

### DIFF
--- a/src/ZF/Hal/Plugin/Hal.php
+++ b/src/ZF/Hal/Plugin/Hal.php
@@ -700,6 +700,10 @@ class Hal extends AbstractHelper implements
      */
     public function injectSelfLink(LinkCollectionAwareInterface $resource, $route, $identifier = 'id')
     {
+        if ($resource->getLinks()->has('self')) {
+            return;
+        }
+
         $self = new Link('self');
         $self->setRoute($route);
 


### PR DESCRIPTION
When a custom/abstract resource collection defines the _links for itself (to set custom url parameters) zf-hal is overwriting the 'self' _link. 

This prevents automatic setting of the 'self' if it already exists.
