### PR TITLE
Use the exsisting link collection when properties are links.

### DIFF
--- a/src/ZF/Hal/Plugin/Hal.php
+++ b/src/ZF/Hal/Plugin/Hal.php
@@ -431,6 +431,18 @@ class Hal extends AbstractHelper implements
                 $halResource->getLinks()->add($value);
                 unset($resource[$key]);
             }
+            if($value instanceof LinkCollection){
+                array_walk_recursive($value, function($link, $rel) use ($halResource){
+                    if(!($link instanceof Link)){
+                        throw new DomainException(sprintf(
+                            'Link object for relation "%s" in resource was malformed; cannot add link',
+                            $rel
+                        ));
+                    }
+                    $halResource->getLinks()->add($link);
+                });
+                unset($resource[$key]);
+            }
         }
 
         $links    = $this->fromResource($halResource);


### PR DESCRIPTION
This seems to be the expected behaviour, as every other link uses the 'relation' property of the link. 

Allows resources to contain an embedded resource and a link with the same name:

```
$resource['account'] = $account; //object
$link = new Link('account'); //this is the name
$link->setRoute('accounts');
$link->setRouteParams(['id' => $account->getId()]);
$resource['account_link] = $link; //this key doesn't really matter
```

Output:

```
{
    "id": "1234",
    "_embedded": {
        "account": {
            "id": "5678",
            "name": "Account Name",
            "_links": {
                "self": {
                    "href": "http://localhost/accounts/5678"
                }
            }
        }
    },
    "_links": {
        "self": {
            "href": "http://localhost/users/1234"
        },
        "account": {
            "href": "http://localhost/accounts/5678"
        }
    }
}
```

Also enables arrays of links:

```
$link1 = new Link('friends');
$link1->setUrl('users/1234');
$link1->setProps(['name' => 'Tim']);

$link2 = new Link('friends');
$link2->setUrl('users/5678');
$link2->setProps(['name' => 'Kate']);

$resource[] = $link1;
$resource[] = $link2;
```

Output:

```
{
    "links": {
        "friends": [
            {
                "name": "Tim",
                "href": "http://localhost/users/1234"
            },
            {
                "name": "Kate",
                "href": "http://localhost/users/5678"
            }
        ]
    }
}
```
