### PR TITLE
Seed route 'params' with the resource identifier.

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -24,7 +24,8 @@ return array(
             //             'url'   => 'string absolute URI to use', // OR
             //             'route' => array(
             //                 'name'    => 'route name for this link',
-            //                 'params'  => array( /* any route params to use for link generation */ ),
+            //                 'params'  => array( /* any route params to use for link generation, link generation logic
+            //                                        automatically seed this array with the identifier of this resource */ ),
             //                 'options' => array( /* any options to pass to the router */ ),
             //             ),
             //         ),

--- a/src/ZF/Hal/Plugin/Hal.php
+++ b/src/ZF/Hal/Plugin/Hal.php
@@ -618,7 +618,7 @@ class Hal extends AbstractHelper implements
 
         $resource = new Resource($data, $id);
         $links    = $resource->getLinks();
-        $this->marshalMetadataLinks($metadata, $links);
+        $this->marshalMetadataLinks($metadata, $links, $id, $identiferName);
         if (!$links->has('self')) {
             $link = $this->marshalSelfLinkFromMetadata($metadata, $object, $id, $identiferName);
             $links->add($link);
@@ -1037,10 +1037,23 @@ class Hal extends AbstractHelper implements
      *
      * @param  Metadata $metadata
      * @param  LinkCollection $links
+     * @param  null|string $id
+     * @param  null|string $identifierName
      */
-    protected function marshalMetadataLinks(Metadata $metadata, LinkCollection $links)
+    protected function marshalMetadataLinks(Metadata $metadata, LinkCollection $links, $id = null, $identifierName = null)
     {
         foreach ($metadata->getLinks() as $linkData) {
+            // Seed the route params with the identifier of this resource
+            if ($id
+                && $identifierName
+                && isset($linkData['route'])
+                && is_array($linkData['route'])
+            ) {
+                $params = isset($linkData['route']['params'])
+                                && is_array($linkData['route']['params']) ? $linkData['route']['params'] : array();
+                $linkData['route']['params'] = array_merge($params, array($identifierName => $id));
+            }
+
             $link = Link::factory($linkData);
             $links->add($link);
         }


### PR DESCRIPTION
With this improvement we could be defining links of a recently created resource using routes that depend of that resource identifier.

This bug zfcampus/zf-apigility-admin#43 get fixed with this commit.
