### PR TITLE
Add support for JsonSerializable resources.

### DIFF
--- a/src/ZF/Hal/Plugin/Hal.php
+++ b/src/ZF/Hal/Plugin/Hal.php
@@ -7,6 +7,7 @@
 namespace ZF\Hal\Plugin;
 
 use ArrayObject;
+use JsonSerializable;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\EventManagerAwareInterface;
 use Zend\EventManager\EventManagerInterface;
@@ -1003,6 +1004,10 @@ class Hal extends AbstractHelper implements
      */
     protected function convertResourceToArray($resource)
     {
+        if ($resource instanceof JsonSerializable) {
+            return $resource->jsonSerialize();
+        }
+
         $hydrator = $this->getHydratorForResource($resource);
         if (!$hydrator) {
             return (array) $resource;

--- a/test/ZFTest/Hal/Plugin/HalTest.php
+++ b/test/ZFTest/Hal/Plugin/HalTest.php
@@ -306,6 +306,16 @@ class HalTest extends TestCase
         $this->assertRelationalLinkContains('/embedded_custom/baz', 'self', $second);
     }
 
+    public function testRendersJsonSerializableObjectUsingJsonserializeMethod()
+    {
+        $object   = new TestAsset\JsonSerializableResource('foo', 'Foo');
+        $resource = new Resource($object, 'foo');
+        $rendered = $this->plugin->renderResource($resource);
+        $this->assertArrayHasKey('id', $rendered);
+        $this->assertArrayNotHasKey('name', $rendered);
+        $this->assertArrayHasKey('_links', $rendered);
+    }
+
     public function testRendersEmbeddedCollectionsInsideResourcesBasedOnMetadataMap()
     {
         $collection = new TestAsset\Collection(

--- a/test/ZFTest/Hal/Plugin/TestAsset/JsonSerializableResource.php
+++ b/test/ZFTest/Hal/Plugin/TestAsset/JsonSerializableResource.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2013 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Hal\Plugin\TestAsset;
+
+use JsonSerializable;
+
+class JsonSerializableResource extends Resource implements JsonSerializable
+{
+    public function __construct($id, $name)
+    {
+        $this->id   = $id;
+        $this->name = $name;
+    }
+
+    public function jsonSerialize()
+    {
+        return array(
+            'id' => $this->id,
+        );
+    }
+}


### PR DESCRIPTION
Since Apigility ultimately serializes things to json, one would expect
when entities/resources implement JsonSerializable, that it would be
used. This was not the case because Zf\Hal\Plugin\Hal was converting
everything to an array first before encoding to json. Now, if an
entity/resource is JsonSerializable, it will prefer the result of
jsonSerialize() rather than falling back to a given hydrator or casting
the object to an array.

It might be desireable to override or toggle this behavior, in the event
a user wants to have a JsonSerializable entity, but still have Apigility
use a specified hydrator. If anyone complains about this, we could add
an option for toggling the order, or break up getHydratorForResource()
so that we can:
1. Check if a specific hydrator is set for that entity/resource.
2. If not, check if it's JsonSerializable.
3. If it's not, check if we have a default/fallback hydrator set.
4. If none of the above work, then finally cast to array.

That would provide the best of both worlds, but currently the
getHydratorForResource() method simply returns the specific hydrator if
specified, and quietly falls back to the default hydrator, so at the
convertResourceToArray() scope, we can't run logic to do something in
one case or the other.
