### PR TITLE
Allow the metdata route params to include callables:

### DIFF
--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -1167,6 +1167,22 @@ class Hal extends AbstractHelper implements
         }
 
         $params = $metadata->getRouteParams();
+
+        //process any callbacks
+        foreach($params as $key => $param){
+            //bind to the object if supported
+            if($param instanceof \Closure){
+                if(is_callable(array($param, 'bindTo'))){
+                    $param = $param->bindTo($object);
+                }
+            }
+
+            //pass the object for callbacks and non-bound closures
+            if(is_callable($param)){
+                $params[$key] = $param($object);
+            }
+        }
+
         if ($routeIdentifierName) {
             $params = array_merge($params, array($routeIdentifierName => $id));
         }

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -775,6 +775,62 @@ class HalTest extends TestCase
     }
 
     /**
+     * Test that the hal metadata route params config allows callables. All callables should be passed the object
+     * being used for entity creation. If closure binding is supported, any closures should be bound to that object.
+     *
+     * The return value should be used as the route param for the link (in place of the callable).
+     */
+    public function testRouteParamsAllowsCallable()
+    {
+        $object = new TestAsset\Entity('foo', 'Foo');
+
+        $callback = $this->getMock('stdClass', array('callback'));
+        $callback->expects($this->atLeastOnce())
+                 ->method('callback')
+                 ->with($this->equalTo($object))
+                 ->will($this->returnValue('callback-param'));
+
+        $closure = function(){};
+
+        $canBind = is_callable(array($closure, 'bindTo'));
+        $test = $this;
+
+        $metadata = new MetadataMap(array(
+            'ZFTest\Hal\Plugin\TestAsset\Entity' => array(
+                'hydrator'     => 'Zend\Stdlib\Hydrator\ObjectProperty',
+                'route_name'   => 'hostname/resource',
+                'route_params' => [
+                    'test-1' => array($callback, 'callback'),
+                    'test-2' => function($expected) use ($object, $canBind, $test){
+                        $test->assertSame($expected, $object);
+                        if($canBind){
+                            $test->assertSame($object, $this);
+                        }
+
+                        return 'closure-param';
+                    }
+                ]
+            ),
+        ));
+
+        $this->plugin->setMetadataMap($metadata);
+        $entity = $this->plugin->createEntityFromMetadata($object, $metadata->get('ZFTest\Hal\Plugin\TestAsset\Entity'));
+        $this->assertInstanceof('ZF\Hal\Entity', $entity);
+
+        $links = $entity->getLinks();
+        $this->assertTrue($links->has('self'));
+
+        $self = $links->get('self');
+        $params = $self->getRouteParams();
+
+        $this->assertArrayHasKey('test-1', $params);
+        $this->assertEquals('callback-param', $params['test-1']);
+
+        $this->assertArrayHasKey('test-2', $params);
+        $this->assertEquals('closure-param', $params['test-2']);
+    }
+
+    /**
      * @group 79
      */
     public function testRenderEntityTriggersEvent()


### PR DESCRIPTION
- On entity creation, any callable is passed the object the entity
  is being created from.
- If the callable is a closure, and `bindTo()` is supported, the
  closure is bound to the object.
- The return value replaces the callable in the route param array
  before the array is passed to the `Link`.

Example with callable:

``` php
    'route_params' => [
        'parent_id' => [$someService, 'getParentId']
    ]
```

Example with binding:

``` php
    'route_params' => [
        'parent_id' => function(){
            return $this->getParent()->getId();
        }
    ]
```
