### PR TITLE
Fix for incorrect treatment of every callable as a closure.

### DIFF
--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -1172,15 +1172,13 @@ class Hal extends AbstractHelper implements
         // process any callbacks
         foreach ($params as $key => $param) {
             // bind to the object if supported
-            if ($param instanceof Closure) {
-                if (is_callable(array($param, 'bindTo'))) {
-                    $param = $param->bindTo($object);
-                }
+            if ($param instanceof Closure AND version_compare(PHP_VERSION, '5.4.0') >= 0) {
+                $param = $param->bindTo($object);
             }
 
             // pass the object for callbacks and non-bound closures
             if (is_callable($param)) {
-                $params[$key] = $param($object);
+                $params[$key] = call_user_func_array($param, array($object));
             }
         }
 

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -794,11 +794,6 @@ class HalTest extends TestCase
                  ->with($this->equalTo($object))
                  ->will($this->returnValue('callback-param'));
 
-        $closure = function () {
-            // does nothing
-        };
-
-        $canBind = is_callable(array($closure, 'bindTo'));
         $test = $this;
 
         $metadata = new MetadataMap(array(
@@ -807,9 +802,9 @@ class HalTest extends TestCase
                 'route_name'   => 'hostname/resource',
                 'route_params' => array(
                     'test-1' => array($callback, 'callback'),
-                    'test-2' => function ($expected) use ($object, $canBind, $test) {
+                    'test-2' => function ($expected) use ($object, $test) {
                         $test->assertSame($expected, $object);
-                        if ($canBind) {
+                        if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
                             $test->assertSame($object, $this);
                         }
 


### PR DESCRIPTION
Also using version_compare to determine binding.
