### PR TITLE
don't output empty collections

### DIFF
--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -975,10 +975,12 @@ class Hal extends AbstractHelper implements
     protected function extractEmbeddedCollection(array &$parent, $key, Collection $collection)
     {
         $rendered = $this->extractCollection($collection);
-        if (!isset($parent['_embedded'])) {
-            $parent['_embedded'] = array();
+        if (count($rendered) > 0) {
+            if (!isset($parent['_embedded'])) {
+                $parent['_embedded'] = array();
+            }
+            $parent['_embedded'][$key] = $rendered;
         }
-        $parent['_embedded'][$key] = $rendered;
         unset($parent[$key]);
     }
 


### PR DESCRIPTION
This is a PR to prevent a HAL response like this:

``` json
{
    "key": "value",
    "_embedded": {
        "some-embedded-key": []
    }
}
```

As _embedded is defined as OPTIONAL in [draft-kelly-json-hal-06](https://tools.ietf.org/html/draft-kelly-json-hal-06#section-4.1.2) it doesn't make any sense in my opinion to pollute the response with empty collections.

Feedback and opinions are very welcome.

Thank you.
