### PR TITLE
[#33] Store original entity in Hal\Entity

### DIFF
--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -69,7 +69,7 @@ class Hal extends AbstractHelper implements
 
     /**
      * Map of entities to their ZF\Hal\Entity serializations
-     * 
+     *
      * @var SplObjectStorage
      */
     protected $serializedEntities;

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -1089,7 +1089,7 @@ class HalTest extends TestCase
     /**
      * Test that the convertEntityToArray() caches serialization results by object.
      *
-     * This is done because if you call createEntity() -- say, from a ZF\Rest\RestController, 
+     * This is done because if you call createEntity() -- say, from a ZF\Rest\RestController,
      * you may end up calling convertEntityToArray() twice -- once to create the HAL
      * entity with the appropriate identifier, and another when creating the serialized
      * representation.


### PR DESCRIPTION
When calling `createEntity()` we should **not** serialize the original object
to an array, as this breaks listeners on `renderEntity`; listeners can no
longer use instanceof to detect the type, as it's always an array.

However, to preserve the original behavior, which is that the returned
`ZF\Hal\Entity` object has an identifier, routing behavior, etc., we need to
use the metadata map in order to serialize the object and extract the
identifier. This leads to a situation where serialization can happen twice --
once when
`createEntity()` is called, and once when `renderEntity()` is called. To
address that situation, this patch also introduces a `serializedEntities`
object, which maps objects to their array representations. This is a fast
lookup, and prevents the double serialization operation.

Doing this allowed removing code from `createEntityFromMetadataMap()`, as the 
logic for extracting the entity was largely duplicated from
`convertEntityToArray()`.

This PR fixes #33, and supercedes #34.
