### PR TITLE
Update Hal Plugin to support entities with $id = 0

### DIFF
--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -1051,7 +1051,7 @@ class Hal extends AbstractHelper implements
             }
 
             $id = $this->getIdFromEntity($entity);
-            if (!$id) {
+            if ($id === false) {
                 // Cannot handle entities without an identifier
                 // Return as-is
                 $collection[] = $entity;


### PR DESCRIPTION
Update Hal Plugin to support entities with `$id = 0`, these were currently not rendered because of a wrong if-clause in the `createEntity` method.
This is related to issues https://github.com/zfcampus/zf-hal/issues/44 and https://github.com/zfcampus/zf-rest/issues/35
