### PR TITLE
Links in metadata map are no longer honored

### DIFF
--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -754,8 +754,9 @@ class Hal extends AbstractHelper implements
 
         switch (true) {
             case (is_object($entity) && $metadataMap->has($entity)):
-                $halEntity = $this->createEntityFromMetadata($entity, $metadataMap->get($entity));
-                $halEntity = new Entity($entity, $halEntity->id);
+                $generatedEntity = $this->createEntityFromMetadata($entity, $metadataMap->get($entity));
+                $halEntity = new Entity($entity, $generatedEntity->id);
+                $halEntity->setLinks($generatedEntity->getLinks());
                 break;
 
             case (! $entity instanceof Entity):


### PR DESCRIPTION
As of fd081c103e, links defined in the metadata map are no longer honored. Per [this mailing list thread](https://groups.google.com/a/zend.com/d/msgid/apigility-users/807fc1f8-fa88-41b3-a5df-ca20bba4e074%40zend.com?utm_medium=email&utm_source=footer), the problem appears to be this:

``` php
            // Starting at line 756:
            case (is_object($entity) && $metadataMap->has($entity)):
                $halEntity = $this->createEntityFromMetadata($entity, $metadataMap->get($entity));
                $halEntity = new Entity($entity, $halEntity->id);
                break;
```

Essentially, any links created during `createEntityFromMetadata()` are thrown out.

The solution will be to inject the new `ZF\Hal\Entity` instance with any links composed in the returned `$halEntity`.
