### PR TITLE
Fix: Remove unused local variable

### DIFF
--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -487,7 +487,6 @@ class Hal extends AbstractHelper implements
     {
         $this->getEventManager()->trigger(__FUNCTION__, $this, array('entity' => $halEntity));
         $entity        = $halEntity->entity;
-        $id            = $halEntity->id;
         $entityLinks   = $halEntity->getLinks();
         $metadataMap   = $this->getMetadataMap();
 


### PR DESCRIPTION
Local variable `$id` is never used.
