### PR TITLE
Fix: PHPDoc comments / signatures

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -136,6 +136,7 @@ class Collection implements Link\LinkCollectionAwareInterface
      *
      * @param  string $name
      * @return mixed
+     * @throws \Exception
      */
     public function __get($name)
     {
@@ -227,7 +228,7 @@ class Collection implements Link\LinkCollectionAwareInterface
     /**
      * Set the route identifier name
      *
-     * @param  string $name
+     * @param  string $identifier
      * @return self
      */
     public function setRouteIdentifierName($identifier)
@@ -239,7 +240,7 @@ class Collection implements Link\LinkCollectionAwareInterface
     /**
      * Set the route identifier name
      *
-     * @param  string $name
+     * @param  string $identifier
      * @return self
      */
     public function setEntityIdentifierName($identifier)

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -36,6 +36,7 @@ class Entity implements Link\LinkCollectionAwareInterface
      * Retrieve properties
      *
      * @param  string $name
+     * @throws Exception\InvalidArgumentException
      * @return mixed
      */
     public function &__get($name)

--- a/src/Link/Link.php
+++ b/src/Link/Link.php
@@ -144,6 +144,7 @@ class Link
      * @param  null|array|Traversable $params
      * @param  null|array|Traversable $options
      * @return self
+     * @throws DomainException
      */
     public function setRoute($route, $params = null, $options = null)
     {
@@ -169,6 +170,7 @@ class Link
      *
      * @param  array|Traversable $options
      * @return self
+     * @throws Exception\InvalidArgumentException
      */
     public function setRouteOptions($options)
     {
@@ -193,6 +195,7 @@ class Link
      *
      * @param  array|Traversable $params
      * @return self
+     * @throws Exception\InvalidArgumentException
      */
     public function setRouteParams($params)
     {
@@ -217,6 +220,8 @@ class Link
      *
      * @param  string $url
      * @return self
+     * @throws DomainException
+     * @throws Exception\InvalidArgumentException
      */
     public function setUrl($url)
     {

--- a/src/Link/LinkCollection.php
+++ b/src/Link/LinkCollection.php
@@ -47,6 +47,7 @@ class LinkCollection implements Countable, IteratorAggregate
      * @param  Link $link
      * @param  bool $overwrite
      * @return self
+     * @throws Exception\DomainException
      */
     public function add(Link $link, $overwrite = false)
     {

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -113,6 +113,7 @@ class Metadata
      *
      * @param  string $class
      * @param  array $options
+     * @param  HydratorPluginManager $hydrators
      * @throws Exception\InvalidArgumentException
      */
     public function __construct($class, array $options = array(), HydratorPluginManager $hydrators = null)

--- a/src/Metadata/MetadataMap.php
+++ b/src/Metadata/MetadataMap.php
@@ -71,6 +71,7 @@ class MetadataMap
      *
      * @param  array $map
      * @return self
+     * @throws Exception\InvalidArgumentException
      */
     public function setMap(array $map)
     {

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -154,6 +154,7 @@ class Hal extends AbstractHelper implements
      * Set the event manager instance
      *
      * @param  EventManagerInterface $events
+     * @return self
      */
     public function setEventManager(EventManagerInterface $events)
     {
@@ -247,7 +248,8 @@ class Hal extends AbstractHelper implements
      *
      * @param  string $class
      * @param  HydratorInterface $hydrator
-     * @return RestfulJsonRenderer
+     * @return self
+     * @throws Exception\InvalidArgumentException
      */
     public function addHydrator($class, $hydrator)
     {
@@ -269,7 +271,7 @@ class Hal extends AbstractHelper implements
      * Set the default hydrator to use if none specified for a class.
      *
      * @param  HydratorInterface $hydrator
-     * @return RestfulJsonRenderer
+     * @return self
      */
     public function setDefaultHydrator(HydratorInterface $hydrator)
     {
@@ -281,7 +283,8 @@ class Hal extends AbstractHelper implements
      * Set boolean to render embedded eneities or just include _embedded data
      *
      * @deprecated
-     * @var boolean
+     * @param  boolean $value
+     * @return self
      */
     public function setRenderEmbeddedResources($value)
     {
@@ -293,7 +296,8 @@ class Hal extends AbstractHelper implements
     /**
      * Set boolean to render embedded entities or just include _embedded data
      *
-     * @var boolean
+     * @param  boolean $value
+     * @return self
      */
     public function setRenderEmbeddedEntities($value)
     {
@@ -326,7 +330,8 @@ class Hal extends AbstractHelper implements
     /**
      * Set boolean to render embedded collections or just include _embedded data
      *
-     * @var boolean
+     * @param  boolean $value
+     * @return self
      */
     public function setRenderCollections($value)
     {
@@ -481,6 +486,7 @@ class Hal extends AbstractHelper implements
      * Entity objects, they are extracted into an "_embedded" hash.
      *
      * @param  Entity $halEntity
+     * @param  bool $renderEntity
      * @return array
      */
     public function renderEntity(Entity $halEntity, $renderEntity = true)
@@ -575,7 +581,7 @@ class Hal extends AbstractHelper implements
      *
      * @param  Link $linkDefinition
      * @return array
-     * @throws Exception\DomainException if Link is incomplete
+     * @throws DomainException
      */
     public function fromLink(Link $linkDefinition)
     {
@@ -625,6 +631,7 @@ class Hal extends AbstractHelper implements
      *
      * @param  LinkCollection $collection
      * @return array
+     * @throws DomainException
      */
     public function fromLinkCollection(LinkCollection $collection)
     {
@@ -675,6 +682,7 @@ class Hal extends AbstractHelper implements
      * @deprecated
      * @param  object $object
      * @param  Metadata $metadata
+     * @param  bool $renderEmbeddedEntities
      * @return Entity|Collection
      */
     public function createResourceFromMetadata($object, Metadata $metadata, $renderEmbeddedEntities = true)
@@ -688,7 +696,9 @@ class Hal extends AbstractHelper implements
      *
      * @param  object $object
      * @param  Metadata $metadata
+     * @param  bool $renderEmbeddedEntities
      * @return Entity|Collection
+     * @throws Exception\RuntimeException
      */
     public function createEntityFromMetadata($object, Metadata $metadata, $renderEmbeddedEntities = true)
     {
@@ -829,7 +839,7 @@ class Hal extends AbstractHelper implements
      *
      * @param  LinkCollectionAwareInterface $resource
      * @param  string $route
-     * @param  string $identifier
+     * @param  string $routeIdentifier
      */
     public function injectSelfLink(LinkCollectionAwareInterface $resource, $route, $routeIdentifier = 'id')
     {


### PR DESCRIPTION
This PR
- updates PHPDoc comments to match actual method signatures
- adds missing `throws` annotations
