### PR TITLE
Fix HAL helper injection into HelperPluginManager

### DIFF
--- a/src/View/HalJsonRenderer.php
+++ b/src/View/HalJsonRenderer.php
@@ -12,7 +12,6 @@ use Zend\View\ViewEvent;
 use ZF\ApiProblem\ApiProblem;
 use ZF\ApiProblem\View\ApiProblemModel;
 use ZF\ApiProblem\View\ApiProblemRenderer;
-use ZF\Hal\Plugin\Hal as HalHelper;
 
 /**
  * Handles rendering of the following:
@@ -55,9 +54,6 @@ class HalJsonRenderer extends JsonRenderer
      */
     public function setHelperPluginManager(HelperPluginManager $helpers)
     {
-        if (!$helpers->has('Hal')) {
-            $this->injectHalHelper($helpers);
-        }
         $this->helpers = $helpers;
     }
 
@@ -128,21 +124,6 @@ class HalJsonRenderer extends JsonRenderer
         }
 
         return parent::render($nameOrModel, $values);
-    }
-
-    /**
-     * Inject the helper manager with the Hal helper
-     *
-     * @param  HelperPluginManager $helpers
-     */
-    protected function injectHalHelper(HelperPluginManager $helpers)
-    {
-        $helper = new HalHelper();
-        $helper
-            ->setView($this)
-            ->setServerUrlHelper($helpers->get('ServerUrl'))
-            ->setUrlHelper($helpers->get('Url'));
-        $helpers->setService('Hal', $helper);
     }
 
     /**

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -16,7 +16,6 @@ use Zend\Mvc\MvcEvent;
 use Zend\Paginator\Adapter\ArrayAdapter as ArrayPaginator;
 use Zend\Paginator\Paginator;
 use Zend\Uri\Http;
-use Zend\Uri\Uri;
 use Zend\View\Helper\Url as UrlHelper;
 use Zend\View\Helper\ServerUrl as ServerUrlHelper;
 use ZF\Hal\Collection;

--- a/test/View/HalJsonRendererTest.php
+++ b/test/View/HalJsonRendererTest.php
@@ -617,13 +617,4 @@ class HalJsonRendererTest extends TestCase
             $this->assertEquals('bar', $item->foo);
         }
     }
-
-    public function testHelperPluginManagerSetterInjectsHalPluginWhenDoesNotRegistered()
-    {
-        $helpers = new HelperPluginManager();
-        $this->renderer->setHelperPluginManager($helpers);
-
-        $halPlugin = $helpers->get('hal');
-        $this->assertInstanceOf('ZF\Hal\Plugin\Hal', $halPlugin);
-    }
 }


### PR DESCRIPTION
The alias `HalHelper` of `ZF\Hal\Plugin\Hal` class was not declared.
