### PR TITLE
Set page and pageSize from paginator

### DIFF
--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -435,6 +435,9 @@ class Hal extends AbstractHelper implements
         $collectionName = $halCollection->getCollectionName();
 
         if ($collection instanceof Paginator) {
+            $halCollection->setPage($collection->getCurrentPageNumber());
+            $halCollection->setPageSize($collection->getItemCountPerPage());
+
             $status = $this->injectPaginationLinks($halCollection);
             if ($status instanceof ApiProblem) {
                 return $status;


### PR DESCRIPTION
HAL has it's own values for page and pageSize and I think these should be fetched from the Zend Paginator if the HAL Collection is a paginator.

The last two lines here should be unnecessary

```php
        $paginator = new ZendPaginator($adapter);
        $paginator->setItemCountPerPage(100);
        $paginator->setCurrentPageNumber($page);

        $hal = new Collection($paginator);
        $hal->setCollectionName('listing');
        $hal->setCollectionRoute('collectionRoute');
        $hal->setPage($paginator->getCurrentPageNumber());
        $hal->setPageSize($paginator->getItemCountPerPage());
```

This pull request is made prior to fixing unit tests to see if it will fly.