### PR TITLE
Work around infinite nesting while working with Doctrine entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Each class in the metadata map may contain one or more of the following configur
 - `route_params` - an array of route parameters to use for link generation.
 - `route_options` - an array of options to pass to the router during link generation.
 - `url` - specific URL to use with this resource, if not using a route.
+- `max_depth` - limit to what nesting level entities and collections are rendered; if the limit is 
+reached, only `self` links will be rendered.
 
 The `links` property is an array of arrays, each with the following structure:
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Each class in the metadata map may contain one or more of the following configur
 - `route_params` - an array of route parameters to use for link generation.
 - `route_options` - an array of options to pass to the router during link generation.
 - `url` - specific URL to use with this resource, if not using a route.
-- `max_depth` - limit to what nesting level entities and collections are rendered; if the limit is 
+- `max_depth` - integer; limit to what nesting level entities and collections are rendered; if the limit is 
 reached, only `self` links will be rendered.
 
 The `links` property is an array of arrays, each with the following structure:

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -131,6 +131,11 @@ class Collection implements Link\LinkCollectionAwareInterface
         }
     }
 
+    public function setCollection($collection)
+    {
+        $this->collection = $collection;
+    }
+
     /**
      * Proxy to properties to allow read access
      *

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -103,6 +103,11 @@ class Metadata
     protected $url;
 
     /**
+     * @var integer
+     */
+    protected $max_depth;
+
+    /**
      * Constructor
      *
      * Sets the class, and passes any options provided to the appropriate
@@ -312,6 +317,11 @@ class Metadata
     public function getUrl()
     {
         return $this->url;
+    }
+
+    public function getMaxDepth()
+    {
+        return $this->max_depth;
     }
 
     /**
@@ -530,6 +540,15 @@ class Metadata
     public function setUrl($url)
     {
         $this->url = $url;
+        return $this;
+    }
+
+    /**
+     * 
+     */
+    public function setMaxDepth($max_depth)
+    {
+        $this->max_depth = $max_depth;
         return $this;
     }
 }

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -103,9 +103,11 @@ class Metadata
     protected $url;
 
     /**
+     * Maximum number of nesting levels
+     *
      * @var integer
      */
-    protected $max_depth;
+    protected $maxDepth;
 
     /**
      * Constructor
@@ -321,7 +323,7 @@ class Metadata
 
     public function getMaxDepth()
     {
-        return $this->max_depth;
+        return $this->maxDepth;
     }
 
     /**
@@ -544,11 +546,11 @@ class Metadata
     }
 
     /**
-     * 
+     * Set the maximum number of nesting levels
      */
-    public function setMaxDepth($max_depth)
+    public function setMaxDepth($maxDepth)
     {
-        $this->max_depth = $max_depth;
+        $this->maxDepth = $maxDepth;
         return $this;
     }
 }

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -436,7 +436,7 @@ class Hal extends AbstractHelper implements
      * @param  Collection $halCollection
      * @return array|ApiProblem Associative array representing the payload to render; returns ApiProblem if error in pagination occurs
      */
-    public function renderCollection(Collection $halCollection, $depth = 0)
+    public function renderCollection(Collection $halCollection)
     {
         $this->getEventManager()->trigger(__FUNCTION__, $this, array('collection' => $halCollection));
         $collection     = $halCollection->getCollection();
@@ -452,7 +452,7 @@ class Hal extends AbstractHelper implements
         $payload = $halCollection->getAttributes();
         $payload['_links']    = $this->fromResource($halCollection);
         $payload['_embedded'] = array(
-            $collectionName => $this->extractCollection($halCollection, $depth + 1),
+            $collectionName => $this->extractCollection($halCollection),
         );
 
         if ($collection instanceof Paginator) {
@@ -482,6 +482,7 @@ class Hal extends AbstractHelper implements
     {
         trigger_error(sprintf('The method %s is deprecated; please use %s::renderEntity()', __METHOD__, __CLASS__), E_USER_DEPRECATED);
         $this->getEventManager()->trigger(__FUNCTION__, $this, array('resource' => $halResource));
+
         return $this->renderEntity($halResource, $renderResource, $depth + 1);
     }
 
@@ -517,7 +518,7 @@ class Hal extends AbstractHelper implements
             $entity = array();
         }
 
-        if ($this->maxDepth && $depth > $this->maxDepth) {
+        if ($this->maxDepth and $depth > $this->maxDepth) {
             $entity = array();
         }
 
@@ -987,10 +988,13 @@ class Hal extends AbstractHelper implements
      */
     protected function extractEmbeddedEntity(array &$parent, $key, Entity $entity, $depth = 0)
     {
-        $rendered = $this->renderEntity($entity, true, $depth + 1);
+        // No need to increment depth for this call
+        $rendered = $this->renderEntity($entity, true, $depth);
+
         if (!isset($parent['_embedded'])) {
             $parent['_embedded'] = array();
         }
+
         $parent['_embedded'][$key] = $rendered;
         unset($parent[$key]);
     }
@@ -1009,9 +1013,11 @@ class Hal extends AbstractHelper implements
     protected function extractEmbeddedCollection(array &$parent, $key, Collection $collection, $depth = 0)
     {
         $rendered = $this->extractCollection($collection, $depth + 1);
+
         if (!isset($parent['_embedded'])) {
             $parent['_embedded'] = array();
         }
+
         $parent['_embedded'][$key] = $rendered;
         unset($parent[$key]);
     }

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -504,6 +504,7 @@ class Hal extends AbstractHelper implements
         $entityLinks   = $halEntity->getLinks();
         $metadataMap   = $this->getMetadataMap();
 
+
         if (!$this->maxDepth && is_object($entity) && $metadataMap->has($entity)) {
             $this->maxDepth = $metadataMap->get($entity)->getMaxDepth();
         }
@@ -733,11 +734,12 @@ class Hal extends AbstractHelper implements
         $id = ($entityIdentifierName) ? $data[$entityIdentifierName]: null;
 
         if (!$renderEmbeddedEntities) {
-            $data = array();
+            $entity = new Entity([], $id);
+        } else {
+            $entity = new Entity($object, $id);
         }
 
-        $entity   = new Entity($data, $id);
-        $links    = $entity->getLinks();
+        $links = $entity->getLinks();
         $this->marshalMetadataLinks($metadata, $links);
         if (!$links->has('self')) {
             $link = $this->marshalSelfLinkFromMetadata($metadata, $object, $id, $metadata->getRouteIdentifierName());

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -108,9 +108,11 @@ class Hal extends AbstractHelper implements
 
 
     /**
+     * Maximum number of nesting levels
+     *
      * @var integer
      */
-    protected $max_depth;
+    protected $maxDepth;
 
     /**
      * @param null|HydratorPluginManager $hydrators
@@ -502,8 +504,8 @@ class Hal extends AbstractHelper implements
         $entityLinks   = $halEntity->getLinks();
         $metadataMap   = $this->getMetadataMap();
 
-        if (!$this->max_depth && is_object($entity) && $metadataMap->has($entity)) {
-            $this->max_depth = $metadataMap->get($entity)->getMaxDepth();
+        if (!$this->maxDepth && is_object($entity) && $metadataMap->has($entity)) {
+            $this->maxDepth = $metadataMap->get($entity)->getMaxDepth();
         }
 
         if (!is_array($entity)) {
@@ -514,7 +516,7 @@ class Hal extends AbstractHelper implements
             $entity = array();
         }
 
-        if ($this->max_depth && $depth > $this->max_depth) {
+        if ($this->maxDepth && $depth > $this->maxDepth) {
             $entity = array();
         }
 

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -505,7 +505,6 @@ class Hal extends AbstractHelper implements
         $entityLinks   = $halEntity->getLinks();
         $metadataMap   = $this->getMetadataMap();
 
-
         if (!$this->maxDepth && is_object($entity) && $metadataMap->has($entity)) {
             $this->maxDepth = $metadataMap->get($entity)->getMaxDepth();
         }
@@ -545,6 +544,7 @@ class Hal extends AbstractHelper implements
         }
 
         $entity['_links'] = $this->fromResource($halEntity);
+
         return $entity;
     }
 
@@ -778,7 +778,6 @@ class Hal extends AbstractHelper implements
     public function createEntity($entity, $route, $routeIdentifierName)
     {
         $metadataMap = $this->getMetadataMap();
-
         switch (true) {
             case (is_object($entity) && $metadataMap->has($entity)):
                 $generatedEntity = $this->createEntityFromMetadata($entity, $metadataMap->get($entity));
@@ -1082,6 +1081,7 @@ class Hal extends AbstractHelper implements
             }
 
             $id = $this->getIdFromEntity($entity);
+
             if ($id === false) {
                 // Cannot handle entities without an identifier
                 // Return as-is
@@ -1093,6 +1093,10 @@ class Hal extends AbstractHelper implements
                 $links = $eventParams['entity']->getLinks();
             } else {
                 $links = new LinkCollection();
+            }
+
+            if (isset($entity['links']) && $entity['links'] instanceof LinkCollection) {
+                $links = $entity['links'];
             }
 
             $selfLink = new Link('self');

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -1059,7 +1059,8 @@ class Hal extends AbstractHelper implements
             }
 
             if ($entity instanceof Entity) {
-                $collection[] = $this->renderEntity($entity, $this->getRenderCollections(), $depth + 1);
+                // Depth does not increment at this level
+                $collection[] = $this->renderEntity($entity, $this->getRenderCollections(), $depth);
                 continue;
             }
 

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -518,7 +518,7 @@ class Hal extends AbstractHelper implements
             $entity = array();
         }
 
-        if ($this->maxDepth and $depth > $this->maxDepth) {
+        if (isset($this->maxDepth) && $depth >= $this->maxDepth) {
             $entity = array();
         }
 
@@ -793,8 +793,7 @@ class Hal extends AbstractHelper implements
 
             case ($entity instanceof Entity):
             default:
-                $halEntity = $entity;
-                // nothing special to do
+                $halEntity = $entity; // as is
                 break;
         }
 


### PR DESCRIPTION
While using `zf-apigility-doctrine` and certain (mostly bidirectional) Doctrine entity associations, `zf-hal`'s method of rendering entities can cause infinite nesting (Doctrine keeps on giving). I've added a depth gauge as to prevent just that. A `max_depth` configuration key can be added to a class' `metadata_map` key that need their rendering to be limited in such a way.