### PR TITLE
Pr66 im bart

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Each class in the metadata map may contain one or more of the following configur
 - `route_params` - an array of route parameters to use for link generation.
 - `route_options` - an array of options to pass to the router during link generation.
 - `url` - specific URL to use with this resource, if not using a route.
+- `max_depth` - limit to what nesting level entities and collections are rendered; if the limit is 
+reached, only `self` links will be rendered.
 
 The `links` property is an array of arrays, each with the following structure:
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Each class in the metadata map may contain one or more of the following configur
 - `route_params` - an array of route parameters to use for link generation.
 - `route_options` - an array of options to pass to the router during link generation.
 - `url` - specific URL to use with this resource, if not using a route.
-- `max_depth` - limit to what nesting level entities and collections are rendered; if the limit is 
+- `max_depth` - integer; limit to what nesting level entities and collections are rendered; if the limit is 
 reached, only `self` links will be rendered.
 
 The `links` property is an array of arrays, each with the following structure:

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ Each class in the metadata map may contain one or more of the following configur
 - `route_params` - an array of route parameters to use for link generation.
 - `route_options` - an array of options to pass to the router during link generation.
 - `url` - specific URL to use with this resource, if not using a route.
-- `max_depth` - integer; limit to what nesting level entities and collections are rendered; if the limit is 
-reached, only `self` links will be rendered.
+- `max_depth` - integer; limit to what nesting level entities and collections are 
+  rendered; if the limit is reached, only `self` links will be rendered.
 
 The `links` property is an array of arrays, each with the following structure:
 

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -103,6 +103,11 @@ class Metadata
     protected $url;
 
     /**
+     * @var integer
+     */
+    protected $max_depth;
+
+    /**
      * Constructor
      *
      * Sets the class, and passes any options provided to the appropriate
@@ -318,6 +323,11 @@ class Metadata
     public function getUrl()
     {
         return $this->url;
+    }
+
+    public function getMaxDepth()
+    {
+        return $this->max_depth;
     }
 
     /**
@@ -540,6 +550,15 @@ class Metadata
     public function setUrl($url)
     {
         $this->url = $url;
+        return $this;
+    }
+
+    /**
+     * 
+     */
+    public function setMaxDepth($max_depth)
+    {
+        $this->max_depth = $max_depth;
         return $this;
     }
 }

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -103,9 +103,11 @@ class Metadata
     protected $url;
 
     /**
+     * Maximum number of nesting levels
+     *
      * @var integer
      */
-    protected $max_depth;
+    protected $maxDepth;
 
     /**
      * Constructor
@@ -327,7 +329,7 @@ class Metadata
 
     public function getMaxDepth()
     {
-        return $this->max_depth;
+        return $this->maxDepth;
     }
 
     /**
@@ -554,11 +556,11 @@ class Metadata
     }
 
     /**
-     * 
+     * Set the maximum number of nesting levels
      */
-    public function setMaxDepth($max_depth)
+    public function setMaxDepth($maxDepth)
     {
-        $this->max_depth = $max_depth;
+        $this->maxDepth = $maxDepth;
         return $this;
     }
 }

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -327,6 +327,11 @@ class Metadata
         return $this->url;
     }
 
+    /**
+     * Set the maximum nesting level for embedded resources
+     *
+     * @return int 
+     */
     public function getMaxDepth()
     {
         return $this->maxDepth;
@@ -557,6 +562,9 @@ class Metadata
 
     /**
      * Set the maximum number of nesting levels
+     *
+     * @param integer $maxDepth
+     * @return self
      */
     public function setMaxDepth($maxDepth)
     {

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -785,7 +785,7 @@ class Hal extends AbstractHelper implements
         $id = ($entityIdentifierName) ? $data[$entityIdentifierName]: null;
 
         if (!$renderEmbeddedEntities) {
-            $entity = new Entity([], $id);
+            $entity = new Entity(array(), $id);
         } else {
             $entity = new Entity($object, $id);
         }

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -470,7 +470,7 @@ class Hal extends AbstractHelper implements
      * @return array|ApiProblem Associative array representing the payload to render;
      *     returns ApiProblem if error in pagination occurs
      */
-    public function renderCollection(Collection $halCollection, $depth = 0)
+    public function renderCollection(Collection $halCollection)
     {
         $this->getEventManager()->trigger(__FUNCTION__, $this, array('collection' => $halCollection));
         $collection     = $halCollection->getCollection();
@@ -486,7 +486,7 @@ class Hal extends AbstractHelper implements
         $payload = $halCollection->getAttributes();
         $payload['_links']    = $this->fromResource($halCollection);
         $payload['_embedded'] = array(
-            $collectionName => $this->extractCollection($halCollection, $depth + 1),
+            $collectionName => $this->extractCollection($halCollection),
         );
 
         if ($collection instanceof Paginator) {
@@ -526,6 +526,7 @@ class Hal extends AbstractHelper implements
             __CLASS__
         ), E_USER_DEPRECATED);
         $this->getEventManager()->trigger(__FUNCTION__, $this, array('resource' => $halResource));
+
         return $this->renderEntity($halResource, $renderResource, $depth + 1);
     }
 
@@ -561,7 +562,7 @@ class Hal extends AbstractHelper implements
             $entity = array();
         }
 
-        if ($this->maxDepth && $depth > $this->maxDepth) {
+        if ($this->maxDepth and $depth > $this->maxDepth) {
             $entity = array();
         }
 
@@ -1044,10 +1045,13 @@ class Hal extends AbstractHelper implements
      */
     protected function extractEmbeddedEntity(array &$parent, $key, Entity $entity, $depth = 0)
     {
-        $rendered = $this->renderEntity($entity, true, $depth + 1);
+        // No need to increment depth for this call
+        $rendered = $this->renderEntity($entity, true, $depth);
+
         if (!isset($parent['_embedded'])) {
             $parent['_embedded'] = array();
         }
+
         $parent['_embedded'][$key] = $rendered;
         unset($parent[$key]);
     }
@@ -1066,9 +1070,11 @@ class Hal extends AbstractHelper implements
     protected function extractEmbeddedCollection(array &$parent, $key, Collection $collection, $depth = 0)
     {
         $rendered = $this->extractCollection($collection, $depth + 1);
+
         if (!isset($parent['_embedded'])) {
             $parent['_embedded'] = array();
         }
+
         $parent['_embedded'][$key] = $rendered;
         unset($parent[$key]);
     }

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -114,6 +114,12 @@ class Hal extends AbstractHelper implements
      */
     protected $urlHelper;
 
+
+    /**
+     * @var integer
+     */
+    protected $max_depth;
+
     /**
      * @param null|HydratorPluginManager $hydrators
      */
@@ -462,7 +468,7 @@ class Hal extends AbstractHelper implements
      * @return array|ApiProblem Associative array representing the payload to render;
      *     returns ApiProblem if error in pagination occurs
      */
-    public function renderCollection(Collection $halCollection)
+    public function renderCollection(Collection $halCollection, $depth = 0)
     {
         $this->getEventManager()->trigger(__FUNCTION__, $this, array('collection' => $halCollection));
         $collection     = $halCollection->getCollection();
@@ -478,7 +484,7 @@ class Hal extends AbstractHelper implements
         $payload = $halCollection->getAttributes();
         $payload['_links']    = $this->fromResource($halCollection);
         $payload['_embedded'] = array(
-            $collectionName => $this->extractCollection($halCollection),
+            $collectionName => $this->extractCollection($halCollection, $depth + 1),
         );
 
         if ($collection instanceof Paginator) {
@@ -510,7 +516,7 @@ class Hal extends AbstractHelper implements
      * @param  bool $renderResource
      * @return array
      */
-    public function renderResource(Resource $halResource, $renderResource = true)
+    public function renderResource(Resource $halResource, $renderResource = true, $depth = 0)
     {
         trigger_error(sprintf(
             'The method %s is deprecated; please use %s::renderEntity()',
@@ -518,7 +524,7 @@ class Hal extends AbstractHelper implements
             __CLASS__
         ), E_USER_DEPRECATED);
         $this->getEventManager()->trigger(__FUNCTION__, $this, array('resource' => $halResource));
-        return $this->renderEntity($halResource, $renderResource);
+        return $this->renderEntity($halResource, $renderResource, $depth + 1);
     }
 
     /**
@@ -533,18 +539,26 @@ class Hal extends AbstractHelper implements
      * @param  bool $renderEntity
      * @return array
      */
-    public function renderEntity(Entity $halEntity, $renderEntity = true)
+    public function renderEntity(Entity $halEntity, $renderEntity = true, $depth = 0)
     {
         $this->getEventManager()->trigger(__FUNCTION__, $this, array('entity' => $halEntity));
         $entity      = $halEntity->entity;
         $entityLinks = $halEntity->getLinks();
         $metadataMap = $this->getMetadataMap();
 
+        if (!$this->max_depth && is_object($entity) && $metadataMap->has($entity)) {
+            $this->max_depth = $metadataMap->get($entity)->getMaxDepth();
+        }
+
         if (!is_array($entity)) {
             $entity = $this->convertEntityToArray($entity);
         }
 
         if (!$renderEntity) {
+            $entity = array();
+        }
+
+        if ($this->max_depth && $depth > $this->max_depth) {
             $entity = array();
         }
 
@@ -556,12 +570,11 @@ class Hal extends AbstractHelper implements
                     $this->getRenderEmbeddedEntities()
                 );
             }
-
             if ($value instanceof Entity) {
-                $this->extractEmbeddedEntity($entity, $key, $value);
+                $this->extractEmbeddedEntity($entity, $key, $value, $depth + 1);
             }
             if ($value instanceof Collection) {
-                $this->extractEmbeddedCollection($entity, $key, $value);
+                $this->extractEmbeddedCollection($entity, $key, $value, $depth + 1);
             }
             if ($value instanceof Link) {
                 $entityLinks->add($value);
@@ -1024,9 +1037,9 @@ class Hal extends AbstractHelper implements
      * @param  string $key
      * @param  Entity $entity
      */
-    protected function extractEmbeddedEntity(array &$parent, $key, Entity $entity)
+    protected function extractEmbeddedEntity(array &$parent, $key, Entity $entity, $depth = 0)
     {
-        $rendered = $this->renderEntity($entity);
+        $rendered = $this->renderEntity($entity, true, $depth + 1);
         if (!isset($parent['_embedded'])) {
             $parent['_embedded'] = array();
         }
@@ -1045,9 +1058,9 @@ class Hal extends AbstractHelper implements
      * @param  string $key
      * @param  Collection $collection
      */
-    protected function extractEmbeddedCollection(array &$parent, $key, Collection $collection)
+    protected function extractEmbeddedCollection(array &$parent, $key, Collection $collection, $depth = 0)
     {
-        $rendered = $this->extractCollection($collection);
+        $rendered = $this->extractCollection($collection, $depth + 1);
         if (!isset($parent['_embedded'])) {
             $parent['_embedded'] = array();
         }
@@ -1063,7 +1076,7 @@ class Hal extends AbstractHelper implements
      * @param  Collection $halCollection
      * @return array
      */
-    protected function extractCollection(Collection $halCollection)
+    protected function extractCollection(Collection $halCollection, $depth = 0)
     {
         $collection           = array();
         $events               = $this->getEventManager();
@@ -1092,7 +1105,7 @@ class Hal extends AbstractHelper implements
             }
 
             if ($entity instanceof Entity) {
-                $collection[] = $this->renderEntity($entity, $this->getRenderCollections());
+                $collection[] = $this->renderEntity($entity, $this->getRenderCollections(), $depth + 1);
                 continue;
             }
 
@@ -1106,11 +1119,11 @@ class Hal extends AbstractHelper implements
                 }
 
                 if ($value instanceof Entity) {
-                    $this->extractEmbeddedEntity($entity, $key, $value);
+                    $this->extractEmbeddedEntity($entity, $key, $value, $depth + 1);
                 }
 
                 if ($value instanceof Collection) {
-                    $this->extractEmbeddedCollection($entity, $key, $value);
+                    $this->extractEmbeddedCollection($entity, $key, $value, $depth + 1);
                 }
             }
 

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -548,6 +548,7 @@ class Hal extends AbstractHelper implements
         $entityLinks = $halEntity->getLinks();
         $metadataMap = $this->getMetadataMap();
 
+
         if (!$this->maxDepth && is_object($entity) && $metadataMap->has($entity)) {
             $this->maxDepth = $metadataMap->get($entity)->getMaxDepth();
         }
@@ -783,7 +784,9 @@ class Hal extends AbstractHelper implements
         $id = ($entityIdentifierName) ? $data[$entityIdentifierName]: null;
 
         if (!$renderEmbeddedEntities) {
-            $data = array();
+            $entity = new Entity([], $id);
+        } else {
+            $entity = new Entity($object, $id);
         }
 
         $entity = new Entity($data, $id);

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -1116,7 +1116,8 @@ class Hal extends AbstractHelper implements
             }
 
             if ($entity instanceof Entity) {
-                $collection[] = $this->renderEntity($entity, $this->getRenderCollections(), $depth + 1);
+                // Depth does not increment at this level
+                $collection[] = $this->renderEntity($entity, $this->getRenderCollections(), $depth);
                 continue;
             }
 

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -116,9 +116,11 @@ class Hal extends AbstractHelper implements
 
 
     /**
+     * Maximum number of nesting levels
+     *
      * @var integer
      */
-    protected $max_depth;
+    protected $maxDepth;
 
     /**
      * @param null|HydratorPluginManager $hydrators
@@ -546,8 +548,8 @@ class Hal extends AbstractHelper implements
         $entityLinks = $halEntity->getLinks();
         $metadataMap = $this->getMetadataMap();
 
-        if (!$this->max_depth && is_object($entity) && $metadataMap->has($entity)) {
-            $this->max_depth = $metadataMap->get($entity)->getMaxDepth();
+        if (!$this->maxDepth && is_object($entity) && $metadataMap->has($entity)) {
+            $this->maxDepth = $metadataMap->get($entity)->getMaxDepth();
         }
 
         if (!is_array($entity)) {
@@ -558,7 +560,7 @@ class Hal extends AbstractHelper implements
             $entity = array();
         }
 
-        if ($this->max_depth && $depth > $this->max_depth) {
+        if ($this->maxDepth && $depth > $this->maxDepth) {
             $entity = array();
         }
 

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -790,9 +790,7 @@ class Hal extends AbstractHelper implements
             $entity = new Entity($object, $id);
         }
 
-        $entity = new Entity($data, $id);
         $links  = $entity->getLinks();
-
         $this->marshalMetadataLinks($metadata, $links);
 
         if (!$links->has('self')) {

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -114,13 +114,12 @@ class Hal extends AbstractHelper implements
      */
     protected $urlHelper;
 
-
     /**
      * Maximum number of nesting levels
      *
      * @var integer
      */
-    protected $maxDepth;
+    protected $maxDepth = 0;
 
     /**
      * @param null|HydratorPluginManager $hydrators
@@ -562,7 +561,7 @@ class Hal extends AbstractHelper implements
             $entity = array();
         }
 
-        if ($this->maxDepth and $depth > $this->maxDepth) {
+        if ($this->maxDepth && $depth > $this->maxDepth) {
             $entity = array();
         }
 
@@ -774,7 +773,7 @@ class Hal extends AbstractHelper implements
         $data = $this->convertEntityToArray($object);
 
         $entityIdentifierName = $metadata->getEntityIdentifierName();
-        if ($entityIdentifierName and !isset($data[$entityIdentifierName])) {
+        if ($entityIdentifierName && !isset($data[$entityIdentifierName])) {
             throw new Exception\RuntimeException(sprintf(
                 'Unable to determine entity identifier for object of type "%s"; no fields matching "%s"',
                 get_class($object),


### PR DESCRIPTION
This PR extends from #66 and includes:

1. Code style change to camelCase in classes.
2. A presumptuous change https://github.com/TomHAnderson/zf-hal/commit/7d1ef097492839a51c1dde575e64c639fdd266d9
The depth gauge was failing because it expected an entity.  The createEntityFromMetadata function uses the entity hydrator to extract to an array then build a HalEntity from that array and the extracted id.  I believe only the extracted id is necessary for this function to do it's job and it now uses the same entity passed to the function to build the HalEntity.  The job of extracting an entity with a hydrator is convertEntityToArray.
3. Corrected inflated depth guage.

@weierophinney @im-bart