### PR TITLE
Fix: Field is undefined

### DIFF
--- a/src/Link/Link.php
+++ b/src/Link/Link.php
@@ -242,7 +242,7 @@ class Link
             throw new Exception\InvalidArgumentException(sprintf(
                 'Received invalid URL: %s',
                 $e->getMessage()
-            ), $e->getCode, $e);
+            ), $e->getCode(), $e);
         }
 
         if (!$uri->isValid()) {


### PR DESCRIPTION
Attempt to access property `getCode` should probably be a method call to `getCode()`.
