### PR TITLE
[#71] Fix HAL helper/plugin configuration

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -62,12 +62,12 @@ return array(
     ),
     'view_helpers' => array(
         'factories' => array(
-            'Hal' => 'ZF\Hal\Factory\HalPluginFactory',
+            'Hal' => 'ZF\Hal\Factory\HalViewHelperFactory',
         ),
     ),
     'controller_plugins' => array(
         'factories' => array(
-            'Hal' => 'ZF\Hal\Factory\HalPluginFactory',
+            'Hal' => 'ZF\Hal\Factory\HalControllerPluginFactory',
         ),
     ),
 );


### PR DESCRIPTION
- view helper should use `ZF\Hal\Factory\HalViewHelperFactory`
- controller plugin should use `ZF\Hal\Factory\HalControllerPluginFactory`
