### PR TITLE
Resolves #77 -- pull dependency on the hal controller plugin from the service locator

### DIFF
--- a/src/Factory/HalViewHelperFactory.php
+++ b/src/Factory/HalViewHelperFactory.php
@@ -30,7 +30,8 @@ class HalViewHelperFactory implements FactoryInterface
         }
         $urlHelper       = $serviceLocator->get('Url');
 
-        $helper = new Plugin\Hal($hydrators);
+        /** @var Plugin\Hal $helper */
+        $helper = $services->get('ControllerPluginManager')->get('Hal');
         $helper
             ->setMetadataMap($metadataMap)
             ->setServerUrlHelper($serverUrlHelper)

--- a/test/Factory/HalViewHelperFactoryTest.php
+++ b/test/Factory/HalViewHelperFactoryTest.php
@@ -13,6 +13,7 @@ use Zend\Stdlib\Hydrator\HydratorPluginManager;
 use Zend\View\Helper\ServerUrl;
 use Zend\View\Helper\Url;
 use ZF\Hal\Factory\HalViewHelperFactory;
+use ZF\Hal\Plugin;
 
 class HalViewHelperFactoryTest extends TestCase
 {
@@ -21,6 +22,15 @@ class HalViewHelperFactoryTest extends TestCase
         $services = new ServiceManager();
 
         $services->setService('Config', $config);
+
+        $controllerPluginManager = $this->getMock('Zend\ServiceManager\AbstractPluginManager');
+        $controllerPluginManager
+            ->expects($this->once())
+            ->method('get')
+            ->with('Hal')
+            ->will($this->returnValue(new Plugin\Hal()));
+
+        $services->setService('ControllerPluginManager', $controllerPluginManager);
 
         $metadataMap = $this->getMock('ZF\Hal\Metadata\MetadataMap');
         $metadataMap


### PR DESCRIPTION
Made a small change that pulls the dependency on the hal controller plugin from the service locator, this was a hardcoded dependency.