### PR TITLE
Post Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ The `ZF\Hal\Plugin\Hal` triggers several events during its lifecycle. From the `
 instance composed into the HAL plugin, you may attach to the following events:
 
 - `renderCollection`
+- `renderCollection.post`
 - `renderEntity`
+- `renderEntity.post`
 - `createLink`
 - `renderCollection.entity`
 - `getIdFromEntity`

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -502,7 +502,7 @@ class Hal extends AbstractHelper implements
             array('payload' => $payload, 'collection' => $halCollection)
         );
 
-        return $payload;
+        return (array) $payload;
     }
 
     /**
@@ -591,7 +591,7 @@ class Hal extends AbstractHelper implements
             array('payload' => $payload, 'entity' => $halEntity)
         );
 
-        return $payload;
+        return (array) $payload;
     }
 
     /**

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -495,6 +495,13 @@ class Hal extends AbstractHelper implements
             $payload['total_items'] = isset($payload['total_items']) ? $payload['total_items'] : count($collection);
         }
 
+        $payload = new ArrayObject($payload);
+        $this->getEventManager()->trigger(
+            __FUNCTION__ . '.post',
+            $this,
+            array('payload' => $payload, 'collection' => $halCollection)
+        );
+
         return $payload;
     }
 
@@ -576,7 +583,15 @@ class Hal extends AbstractHelper implements
         }
 
         $entity['_links'] = $this->fromResource($halEntity);
-        return $entity;
+
+        $payload = new ArrayObject($entity);
+        $this->getEventManager()->trigger(
+            __FUNCTION__ . '.post',
+            $this,
+            array('payload' => $payload, 'entity' => $halEntity)
+        );
+
+        return $payload;
     }
 
     /**

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -898,12 +898,13 @@ class HalTest extends TestCase
         $rendered = $this->plugin->renderEntity($entity);
         $this->assertContains('/users/matthew', $rendered['_links']['self']['href']);
 
-        $this->plugin->getEventManager()->attach('renderEntity.post', function ($e) {
+        $that = $this;
+        $this->plugin->getEventManager()->attach('renderEntity.post', function ($e) use ($that) {
             $payload = $e->getParam('payload');
             $entity = $e->getParam('entity');
 
-            $this->assertInstanceOf('ArrayObject', $payload);
-            $this->assertInstanceOf('ZF\Hal\Entity', $entity);
+            $that->assertInstanceOf('ArrayObject', $payload);
+            $that->assertInstanceOf('ZF\Hal\Entity', $entity);
 
             $payload['post'] = true;
         });
@@ -940,12 +941,13 @@ class HalTest extends TestCase
         $this->assertArrayHasKey('injected', $rendered);
         $this->assertTrue($rendered['injected']);
 
-        $this->plugin->getEventManager()->attach('renderCollection.post', function ($e) {
+        $that = $this;
+        $this->plugin->getEventManager()->attach('renderCollection.post', function ($e) use ($that) {
             $collection = $e->getParam('collection');
             $payload = $e->getParam('payload');
 
-            $this->assertInstanceOf('ArrayObject', $payload);
-            $this->assertInstanceOf('ZF\Hal\Collection', $collection);
+            $that->assertInstanceOf('ArrayObject', $payload);
+            $that->assertInstanceOf('ZF\Hal\Collection', $collection);
 
             $payload['_post'] = true;
         });


### PR DESCRIPTION
* Added post events to renderEntity and renderCollection
* Each event includes a 'payload' param that's an ArrayObject (to keep
  state). They also include entity/collection params, respectively, if in
  case the original entity/collection is needed.