### PR TITLE
Add page with page_size, page_count

### DIFF
--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -479,6 +479,9 @@ class Hal extends AbstractHelper implements
             $payload['total_items'] = isset($payload['total_items'])
                 ? $payload['total_items']
                 : (int) $collection->getTotalItemCount();
+            $payload['page'] = ($payload['page_count'] > 0)
+                ? $halCollection->getPage()
+                : 0;
         } elseif (is_array($collection) || $collection instanceof Countable) {
             $payload['total_items'] = isset($payload['total_items']) ? $payload['total_items'] : count($collection);
         }

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -1081,9 +1081,11 @@ class HalTest extends TestCase
             'page_count',
             'page_size',
             'total_items',
+            'page',
         );
         $this->assertEquals($expected, array_keys($rendered));
         $this->assertEquals(100, $rendered['total_items']);
+        $this->assertEquals(3, $rendered['page']);
         $this->assertEquals(10, $rendered['page_count']);
         $this->assertEquals(10, $rendered['page_size']);
         return $rendered;


### PR DESCRIPTION
Adds the current page to the retuned HAL at the same level as page_count and page_size.

I do not believe the calling script should need to know what page it's on. In the case of an Angular app which knows only the url to fetch data from the first page will be 1 but when following the _links provided though HAL the page number has no association to the HTML or JS.

By adding the page this is possible in HTML/Angular: Page {{ hal.page }} of {{ hal.page_count }}