### PR TITLE
Fix autoinvokable hydrators usage

### DIFF
--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -261,25 +261,13 @@ class Hal extends AbstractHelper implements
      * @param  string $class
      * @param  HydratorInterface $hydrator
      * @return self
-     * @throws Exception\InvalidArgumentException
      */
     public function addHydrator($class, $hydrator)
     {
         if (!$hydrator instanceof HydratorInterface) {
-            if (!$this->hydrators->has((string) $hydrator)) {
-                $type = gettype($hydrator);
-                if (is_object($hydrator)) {
-                    $type = get_class($hydrator);
-                } elseif (is_string($hydrator)) {
-                    $type = $hydrator;
-                }
-                throw new Exception\InvalidArgumentException(sprintf(
-                    'Invalid hydrator instance or name provided; received "%s"',
-                    $type
-                ));
-            }
             $hydrator = $this->hydrators->get($hydrator);
         }
+
         $class = strtolower($class);
         $this->hydratorMap[$class] = $hydrator;
         return $this;

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -30,6 +30,11 @@ use ZF\Hal\Plugin\Hal as HalHelper;
  */
 class HalTest extends TestCase
 {
+    /**
+     * @var HalHelper
+     */
+    protected $plugin;
+
     public function setUp()
     {
         $this->router = $router = new TreeRouteStack();
@@ -1205,5 +1210,15 @@ class HalTest extends TestCase
         $link = $links->get('self');
         $params = $link->getRouteParams();
         $this->assertEquals(array(), $params);
+    }
+
+    public function testAddHydratorDoesntFailWithAutoInvokables()
+    {
+        $this->plugin->addHydrator('stdClass', 'ZFTest\Hal\Plugin\TestAsset\DummyHydrator');
+
+        $this->assertInstanceOf(
+            'ZFTest\Hal\Plugin\TestAsset\DummyHydrator',
+            $this->plugin->getHydratorForEntity(new \stdClass)
+        );
     }
 }

--- a/test/Plugin/TestAsset/DummyHydrator.php
+++ b/test/Plugin/TestAsset/DummyHydrator.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @author Stefano Torresi (http://stefanotorresi.it)
+ * @license See the file LICENSE.txt for copying permission.
+ * ************************************************
+ */
+
+namespace ZFTest\Hal\Plugin\TestAsset;
+
+use Zend\Stdlib\Hydrator\ArraySerializable;
+
+class DummyHydrator extends ArraySerializable
+{
+
+}

--- a/test/Plugin/TestAsset/DummyHydrator.php
+++ b/test/Plugin/TestAsset/DummyHydrator.php
@@ -1,8 +1,7 @@
 <?php
 /**
- * @author Stefano Torresi (http://stefanotorresi.it)
- * @license See the file LICENSE.txt for copying permission.
- * ************************************************
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
 namespace ZFTest\Hal\Plugin\TestAsset;


### PR DESCRIPTION
currently `ZF\Hal\Plugin::addHydrator()` throws an exception when taking advantage of `AbstractPluginManager::$autoAddInvokableClass` flag, which is on by default.

the additional validation that is being done, which uses `ServiceManager::has()` method, ignores the aforementioned flag, leading to unpredictable behaviours when hydrators may be or may not be already available in the plugin manager (i.e. `AbstractPluginManager::get()` being called somewhere else before `ZF\Hal\Plugin::addHydrator()`)

this PR removes this validation and leaves any validation of hydrator instances to the `HydratorPluginManager` itself, which should throw informative enough exceptions.