### PR TITLE
Fix #66: circular entity references

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Each class in the metadata map may contain one or more of the following configur
 - `route_params` - an array of route parameters to use for link generation.
 - `route_options` - an array of options to pass to the router during link generation.
 - `url` - specific URL to use with this resource, if not using a route.
+- `max_depth` - limit to what nesting level entities and collections are rendered; if the limit is 
+reached, only `self` links will be rendered.
 
 The `links` property is an array of arrays, each with the following structure:
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Each class in the metadata map may contain one or more of the following configur
 - `route_params` - an array of route parameters to use for link generation.
 - `route_options` - an array of options to pass to the router during link generation.
 - `url` - specific URL to use with this resource, if not using a route.
-- `max_depth` - limit to what nesting level entities and collections are rendered; if the limit is 
+- `max_depth` - integer; limit to what nesting level entities and collections are rendered; if the limit is 
 reached, only `self` links will be rendered.
 
 The `links` property is an array of arrays, each with the following structure:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ Each class in the metadata map may contain one or more of the following configur
 - `route_options` - an array of options to pass to the router during link generation.
 - `url` - specific URL to use with this resource, if not using a route.
 - `max_depth` - integer; limit to what nesting level entities and collections are rendered; if the limit is 
-reached, only `self` links will be rendered.
+  reached, only `self` links will be rendered. default value is `null`, which means no limit: if unlimited circular 
+  references are detected, an exception will be thrown to avoid infinite loops.
 
 The `links` property is an array of arrays, each with the following structure:
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -131,6 +131,11 @@ class Collection implements Link\LinkCollectionAwareInterface
         }
     }
 
+    public function setCollection($collection)
+    {
+        $this->collection = $collection;
+    }
+
     /**
      * Proxy to properties to allow read access
      *

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -519,7 +519,7 @@ class Collection implements Link\LinkCollectionAwareInterface
     /**
      * Collection
      *
-     * @return string
+     * @return array|Traversable|\Zend\Paginator\Paginator
      */
     public function getCollection()
     {

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -131,11 +131,6 @@ class Collection implements Link\LinkCollectionAwareInterface
         }
     }
 
-    public function setCollection($collection)
-    {
-        $this->collection = $collection;
-    }
-
     /**
      * Proxy to properties to allow read access
      *

--- a/src/Exception/CircularReferenceException.php
+++ b/src/Exception/CircularReferenceException.php
@@ -1,8 +1,7 @@
 <?php
 /**
- * @author Stefano Torresi (http://stefanotorresi.it)
- * @license See the file LICENSE.txt for copying permission.
- * ************************************************
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
 namespace ZF\Hal\Exception;

--- a/src/Exception/CircularReferenceException.php
+++ b/src/Exception/CircularReferenceException.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @author Stefano Torresi (http://stefanotorresi.it)
+ * @license See the file LICENSE.txt for copying permission.
+ * ************************************************
+ */
+
+namespace ZF\Hal\Exception;
+
+class CircularReferenceException extends RuntimeException
+{
+}

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -103,6 +103,11 @@ class Metadata
     protected $url;
 
     /**
+     * @var integer
+     */
+    protected $max_depth;
+
+    /**
      * Constructor
      *
      * Sets the class, and passes any options provided to the appropriate
@@ -318,6 +323,11 @@ class Metadata
     public function getUrl()
     {
         return $this->url;
+    }
+
+    public function getMaxDepth()
+    {
+        return $this->max_depth;
     }
 
     /**
@@ -540,6 +550,15 @@ class Metadata
     public function setUrl($url)
     {
         $this->url = $url;
+        return $this;
+    }
+
+    /**
+     * 
+     */
+    public function setMaxDepth($max_depth)
+    {
+        $this->max_depth = $max_depth;
         return $this;
     }
 }

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -103,9 +103,11 @@ class Metadata
     protected $url;
 
     /**
+     * Maximum number of nesting levels
+     *
      * @var integer
      */
-    protected $max_depth;
+    protected $maxDepth;
 
     /**
      * Constructor
@@ -327,7 +329,7 @@ class Metadata
 
     public function getMaxDepth()
     {
-        return $this->max_depth;
+        return $this->maxDepth;
     }
 
     /**
@@ -554,11 +556,11 @@ class Metadata
     }
 
     /**
-     * 
+     * Set the maximum number of nesting levels
      */
-    public function setMaxDepth($max_depth)
+    public function setMaxDepth($maxDepth)
     {
-        $this->max_depth = $max_depth;
+        $this->maxDepth = $maxDepth;
         return $this;
     }
 }

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -327,6 +327,11 @@ class Metadata
         return $this->url;
     }
 
+    /**
+     * Retrieve the maximum number of nesting levels
+     *
+     * @return int
+     */
     public function getMaxDepth()
     {
         return $this->maxDepth;
@@ -557,6 +562,9 @@ class Metadata
 
     /**
      * Set the maximum number of nesting levels
+     *
+     * @param  int  $maxDepth
+     * @return self
      */
     public function setMaxDepth($maxDepth)
     {

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -550,7 +550,7 @@ class Hal extends AbstractHelper implements
             $entity = array();
         }
 
-        if ($this->maxDepth and $depth > $this->maxDepth) {
+        if (isset($this->maxDepth) && $depth >= $this->maxDepth) {
             $entity = array();
         }
 
@@ -836,8 +836,7 @@ class Hal extends AbstractHelper implements
 
             case ($entity instanceof Entity):
             default:
-                $halEntity = $entity;
-                // nothing special to do
+                $halEntity = $entity; // as is
                 break;
         }
 

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -537,7 +537,6 @@ class Hal extends AbstractHelper implements
         $entityLinks = $halEntity->getLinks();
         $metadataMap = $this->getMetadataMap();
 
-
         if (!$this->maxDepth && is_object($entity) && $metadataMap->has($entity)) {
             $this->maxDepth = $metadataMap->get($entity)->getMaxDepth();
         }
@@ -581,6 +580,7 @@ class Hal extends AbstractHelper implements
         }
 
         $entity['_links'] = $this->fromResource($halEntity);
+
         return $entity;
     }
 
@@ -821,7 +821,6 @@ class Hal extends AbstractHelper implements
     public function createEntity($entity, $route, $routeIdentifierName)
     {
         $metadataMap = $this->getMetadataMap();
-
         switch (true) {
             case (is_object($entity) && $metadataMap->has($entity)):
                 $generatedEntity = $this->createEntityFromMetadata($entity, $metadataMap->get($entity));
@@ -1125,6 +1124,7 @@ class Hal extends AbstractHelper implements
             }
 
             $id = $this->getIdFromEntity($entity);
+
             if ($id === false) {
                 // Cannot handle entities without an identifier
                 // Return as-is
@@ -1136,6 +1136,10 @@ class Hal extends AbstractHelper implements
                 $links = $eventParams['entity']->getLinks();
             } else {
                 $links = new LinkCollection();
+            }
+
+            if (isset($entity['links']) && $entity['links'] instanceof LinkCollection) {
+                $links = $entity['links'];
             }
 
             $selfLink = new Link('self');

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -458,7 +458,7 @@ class Hal extends AbstractHelper implements
      * @return array|ApiProblem Associative array representing the payload to render;
      *     returns ApiProblem if error in pagination occurs
      */
-    public function renderCollection(Collection $halCollection, $depth = 0)
+    public function renderCollection(Collection $halCollection)
     {
         $this->getEventManager()->trigger(__FUNCTION__, $this, array('collection' => $halCollection));
         $collection     = $halCollection->getCollection();
@@ -474,7 +474,7 @@ class Hal extends AbstractHelper implements
         $payload = $halCollection->getAttributes();
         $payload['_links']    = $this->fromResource($halCollection);
         $payload['_embedded'] = array(
-            $collectionName => $this->extractCollection($halCollection, $depth + 1),
+            $collectionName => $this->extractCollection($halCollection),
         );
 
         if ($collection instanceof Paginator) {
@@ -514,6 +514,7 @@ class Hal extends AbstractHelper implements
             __CLASS__
         ), E_USER_DEPRECATED);
         $this->getEventManager()->trigger(__FUNCTION__, $this, array('resource' => $halResource));
+
         return $this->renderEntity($halResource, $renderResource, $depth + 1);
     }
 
@@ -549,7 +550,7 @@ class Hal extends AbstractHelper implements
             $entity = array();
         }
 
-        if ($this->maxDepth && $depth > $this->maxDepth) {
+        if ($this->maxDepth and $depth > $this->maxDepth) {
             $entity = array();
         }
 
@@ -1030,10 +1031,13 @@ class Hal extends AbstractHelper implements
      */
     protected function extractEmbeddedEntity(array &$parent, $key, Entity $entity, $depth = 0)
     {
-        $rendered = $this->renderEntity($entity, true, $depth + 1);
+        // No need to increment depth for this call
+        $rendered = $this->renderEntity($entity, true, $depth);
+
         if (!isset($parent['_embedded'])) {
             $parent['_embedded'] = array();
         }
+
         $parent['_embedded'][$key] = $rendered;
         unset($parent[$key]);
     }
@@ -1052,9 +1056,11 @@ class Hal extends AbstractHelper implements
     protected function extractEmbeddedCollection(array &$parent, $key, Collection $collection, $depth = 0)
     {
         $rendered = $this->extractCollection($collection, $depth + 1);
+
         if (!isset($parent['_embedded'])) {
             $parent['_embedded'] = array();
         }
+
         $parent['_embedded'][$key] = $rendered;
         unset($parent[$key]);
     }

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -114,7 +114,6 @@ class Hal extends AbstractHelper implements
      */
     protected $urlHelper;
 
-
     /**
      * Maximum number of nesting levels
      *
@@ -576,7 +575,15 @@ class Hal extends AbstractHelper implements
                 if (isset($this->entityReferenceStack[$childEntityHash]) && ! $this->maxDepth) {
                     throw new Exception\CircularReferenceException(sprintf(
                         "Circular reference detected: %s -> %s. %s.",
-                        implode(' -> ', array_map(function($v) { return get_class($v); }, $this->entityReferenceStack)),
+                        implode(
+                            ' -> ',
+                            array_map(
+                                function ($v) {
+                                    return get_class($v);
+                                },
+                                $this->entityReferenceStack
+                            )
+                        ),
                         get_class($value),
                         "Either set a 'max_depth' metadata attribute or remove the reference"
                     ));

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -1102,7 +1102,8 @@ class Hal extends AbstractHelper implements
             }
 
             if ($entity instanceof Entity) {
-                $collection[] = $this->renderEntity($entity, $this->getRenderCollections(), $depth + 1);
+                // Depth does not increment at this level
+                $collection[] = $this->renderEntity($entity, $this->getRenderCollections(), $depth);
                 continue;
             }
 

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -116,9 +116,11 @@ class Hal extends AbstractHelper implements
 
 
     /**
+     * Maximum number of nesting levels
+     *
      * @var integer
      */
-    protected $max_depth;
+    protected $maxDepth;
 
     /**
      * @param null|HydratorPluginManager $hydrators
@@ -534,8 +536,8 @@ class Hal extends AbstractHelper implements
         $entityLinks = $halEntity->getLinks();
         $metadataMap = $this->getMetadataMap();
 
-        if (!$this->max_depth && is_object($entity) && $metadataMap->has($entity)) {
-            $this->max_depth = $metadataMap->get($entity)->getMaxDepth();
+        if (!$this->maxDepth && is_object($entity) && $metadataMap->has($entity)) {
+            $this->maxDepth = $metadataMap->get($entity)->getMaxDepth();
         }
 
         if (!is_array($entity)) {
@@ -546,7 +548,7 @@ class Hal extends AbstractHelper implements
             $entity = array();
         }
 
-        if ($this->max_depth && $depth > $this->max_depth) {
+        if ($this->maxDepth && $depth > $this->maxDepth) {
             $entity = array();
         }
 

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -541,7 +541,9 @@ class Hal extends AbstractHelper implements
             $this->maxDepth = $metadataMap->get($entity)->getMaxDepth();
         }
 
-        if (!$renderEntity) {
+        $limitReached = isset($this->maxDepth) && $depth > $this->maxDepth;
+
+        if (!$renderEntity || $limitReached) {
             $entity = array();
         }
 
@@ -549,15 +551,13 @@ class Hal extends AbstractHelper implements
             $entity = $this->convertEntityToArray($entity);
         }
 
-        $renderEmbedded = ! isset($this->maxDepth) || $depth < $this->maxDepth;
-
         foreach ($entity as $key => $value) {
 
             if (is_object($value) && $metadataMap->has($value)) {
                 $value = $this->createEntityFromMetadata(
                     $value,
                     $metadataMap->get($value),
-                    $this->getRenderEmbeddedEntities() && $renderEmbedded
+                    $this->getRenderEmbeddedEntities()
                 );
             }
 
@@ -1029,12 +1029,6 @@ class Hal extends AbstractHelper implements
      */
     protected function extractEmbeddedEntity(array &$parent, $key, Entity $entity, $depth = 0)
     {
-        unset($parent[$key]);
-
-        if (isset($this->maxDepth) && $depth > $this->maxDepth) {
-            return;
-        }
-
         // No need to increment depth for this call
         $rendered = $this->renderEntity($entity, true, $depth);
 
@@ -1043,6 +1037,7 @@ class Hal extends AbstractHelper implements
         }
 
         $parent['_embedded'][$key] = $rendered;
+        unset($parent[$key]);
     }
 
     /**
@@ -1058,12 +1053,6 @@ class Hal extends AbstractHelper implements
      */
     protected function extractEmbeddedCollection(array &$parent, $key, Collection $collection, $depth = 0)
     {
-        unset($parent[$key]);
-
-        if (isset($this->maxDepth) && $depth > $this->maxDepth) {
-            return;
-        }
-
         $rendered = $this->extractCollection($collection, $depth + 1);
 
         if (!isset($parent['_embedded'])) {
@@ -1071,6 +1060,7 @@ class Hal extends AbstractHelper implements
         }
 
         $parent['_embedded'][$key] = $rendered;
+        unset($parent[$key]);
     }
 
     /**

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -479,7 +479,7 @@ class Hal extends AbstractHelper implements
 
         $metadataMap = $this->getMetadataMap();
 
-        if (!$this->maxDepth && is_object($collection) && $metadataMap->has($collection)) {
+        if ($this->maxDepth === null && is_object($collection) && $metadataMap->has($collection)) {
             $this->maxDepth = $metadataMap->get($collection)->getMaxDepth();
         }
 
@@ -553,7 +553,7 @@ class Hal extends AbstractHelper implements
             $entityHash = spl_object_hash($entity);
             $this->entityReferenceStack[$entityHash] = get_class($entity);
 
-            if (! $this->maxDepth && $metadataMap->has($entity)) {
+            if ($this->maxDepth === null && $metadataMap->has($entity)) {
                 $this->maxDepth = $metadataMap->get($entity)->getMaxDepth();
             }
         }
@@ -572,7 +572,7 @@ class Hal extends AbstractHelper implements
             if (is_object($value) && $metadataMap->has($value)) {
                 $childEntityHash = spl_object_hash($value);
 
-                if (isset($this->entityReferenceStack[$childEntityHash]) && ! $this->maxDepth) {
+                if (isset($this->entityReferenceStack[$childEntityHash]) && $this->maxDepth === null) {
                     $message = sprintf(
                         "Circular reference detected: %s -> %s. %s.",
                         implode(' -> ', $this->entityReferenceStack),
@@ -616,6 +616,11 @@ class Hal extends AbstractHelper implements
         }
 
         $entity['_links'] = $this->fromResource($halEntity);
+
+        if ($limitReached) {
+            // reset the maxDepth so that the same instance of the plugin may be used again on a different metadata map
+            $this->maxDepth = null;
+        }
 
         if (isset($entityHash)) {
             unset($this->entityReferenceStack[$entityHash]);

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -126,7 +126,7 @@ class Hal extends AbstractHelper implements
      *
      * @var array
      */
-    protected $entityReferenceStack = array();
+    protected $entityHashStack = array();
 
     /**
      * @param null|HydratorPluginManager $hydrators
@@ -551,7 +551,7 @@ class Hal extends AbstractHelper implements
 
         if (is_object($entity)) {
             $entityHash = spl_object_hash($entity);
-            $this->entityReferenceStack[$entityHash] = get_class($entity);
+            $this->entityHashStack[$entityHash] = get_class($entity);
 
             if ($this->maxDepth === null && $metadataMap->has($entity)) {
                 $this->maxDepth = $metadataMap->get($entity)->getMaxDepth();
@@ -572,19 +572,19 @@ class Hal extends AbstractHelper implements
             if (is_object($value) && $metadataMap->has($value)) {
                 $childEntityHash = spl_object_hash($value);
 
-                if (isset($this->entityReferenceStack[$childEntityHash]) && $this->maxDepth === null) {
+                if (isset($this->entityHashStack[$childEntityHash]) && $this->maxDepth === null) {
                     $message = sprintf(
                         "Circular reference detected: %s -> %s. %s.",
-                        implode(' -> ', $this->entityReferenceStack),
+                        implode(' -> ', $this->entityHashStack),
                         get_class($value),
                         "Either set a 'max_depth' metadata attribute or remove the reference"
                     );
                     // we need to clear the stack, as the exception may be caught and the plugin may be invoked again
-                    $this->entityReferenceStack = array();
+                    $this->entityHashStack = array();
                     throw new Exception\CircularReferenceException($message);
                 }
 
-                $this->entityReferenceStack[$childEntityHash] = get_class($value);
+                $this->entityHashStack[$childEntityHash] = get_class($value);
 
                 $value = $this->createEntityFromMetadata(
                     $value,
@@ -611,7 +611,7 @@ class Hal extends AbstractHelper implements
             }
 
             if (isset($childEntityHash)) {
-                unset($this->entityReferenceStack[$childEntityHash]);
+                unset($this->entityHashStack[$childEntityHash]);
             }
         }
 
@@ -623,7 +623,7 @@ class Hal extends AbstractHelper implements
         }
 
         if (isset($entityHash)) {
-            unset($this->entityReferenceStack[$entityHash]);
+            unset($this->entityHashStack[$entityHash]);
         }
 
         return $entity;

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -471,6 +471,12 @@ class Hal extends AbstractHelper implements
             }
         }
 
+        $metadataMap = $this->getMetadataMap();
+
+        if (!$this->maxDepth && is_object($collection) && $metadataMap->has($collection)) {
+            $this->maxDepth = $metadataMap->get($collection)->getMaxDepth();
+        }
+
         $payload = $halCollection->getAttributes();
         $payload['_links']    = $this->fromResource($halCollection);
         $payload['_embedded'] = array(

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -536,6 +536,7 @@ class Hal extends AbstractHelper implements
         $entityLinks = $halEntity->getLinks();
         $metadataMap = $this->getMetadataMap();
 
+
         if (!$this->maxDepth && is_object($entity) && $metadataMap->has($entity)) {
             $this->maxDepth = $metadataMap->get($entity)->getMaxDepth();
         }
@@ -775,8 +776,8 @@ class Hal extends AbstractHelper implements
         }
 
         $entity = new Entity($data, $id);
-        $links  = $entity->getLinks();
 
+        $links = $entity->getLinks();
         $this->marshalMetadataLinks($metadata, $links);
 
         if (!$links->has('self')) {

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -114,6 +114,12 @@ class Hal extends AbstractHelper implements
      */
     protected $urlHelper;
 
+
+    /**
+     * @var integer
+     */
+    protected $max_depth;
+
     /**
      * @param null|HydratorPluginManager $hydrators
      */
@@ -450,7 +456,7 @@ class Hal extends AbstractHelper implements
      * @return array|ApiProblem Associative array representing the payload to render;
      *     returns ApiProblem if error in pagination occurs
      */
-    public function renderCollection(Collection $halCollection)
+    public function renderCollection(Collection $halCollection, $depth = 0)
     {
         $this->getEventManager()->trigger(__FUNCTION__, $this, array('collection' => $halCollection));
         $collection     = $halCollection->getCollection();
@@ -466,7 +472,7 @@ class Hal extends AbstractHelper implements
         $payload = $halCollection->getAttributes();
         $payload['_links']    = $this->fromResource($halCollection);
         $payload['_embedded'] = array(
-            $collectionName => $this->extractCollection($halCollection),
+            $collectionName => $this->extractCollection($halCollection, $depth + 1),
         );
 
         if ($collection instanceof Paginator) {
@@ -498,7 +504,7 @@ class Hal extends AbstractHelper implements
      * @param  bool $renderResource
      * @return array
      */
-    public function renderResource(Resource $halResource, $renderResource = true)
+    public function renderResource(Resource $halResource, $renderResource = true, $depth = 0)
     {
         trigger_error(sprintf(
             'The method %s is deprecated; please use %s::renderEntity()',
@@ -506,7 +512,7 @@ class Hal extends AbstractHelper implements
             __CLASS__
         ), E_USER_DEPRECATED);
         $this->getEventManager()->trigger(__FUNCTION__, $this, array('resource' => $halResource));
-        return $this->renderEntity($halResource, $renderResource);
+        return $this->renderEntity($halResource, $renderResource, $depth + 1);
     }
 
     /**
@@ -521,18 +527,26 @@ class Hal extends AbstractHelper implements
      * @param  bool $renderEntity
      * @return array
      */
-    public function renderEntity(Entity $halEntity, $renderEntity = true)
+    public function renderEntity(Entity $halEntity, $renderEntity = true, $depth = 0)
     {
         $this->getEventManager()->trigger(__FUNCTION__, $this, array('entity' => $halEntity));
         $entity      = $halEntity->entity;
         $entityLinks = $halEntity->getLinks();
         $metadataMap = $this->getMetadataMap();
 
+        if (!$this->max_depth && is_object($entity) && $metadataMap->has($entity)) {
+            $this->max_depth = $metadataMap->get($entity)->getMaxDepth();
+        }
+
         if (!is_array($entity)) {
             $entity = $this->convertEntityToArray($entity);
         }
 
         if (!$renderEntity) {
+            $entity = array();
+        }
+
+        if ($this->max_depth && $depth > $this->max_depth) {
             $entity = array();
         }
 
@@ -544,12 +558,11 @@ class Hal extends AbstractHelper implements
                     $this->getRenderEmbeddedEntities()
                 );
             }
-
             if ($value instanceof Entity) {
-                $this->extractEmbeddedEntity($entity, $key, $value);
+                $this->extractEmbeddedEntity($entity, $key, $value, $depth + 1);
             }
             if ($value instanceof Collection) {
-                $this->extractEmbeddedCollection($entity, $key, $value);
+                $this->extractEmbeddedCollection($entity, $key, $value, $depth + 1);
             }
             if ($value instanceof Link) {
                 $entityLinks->add($value);
@@ -1012,9 +1025,9 @@ class Hal extends AbstractHelper implements
      * @param  string $key
      * @param  Entity $entity
      */
-    protected function extractEmbeddedEntity(array &$parent, $key, Entity $entity)
+    protected function extractEmbeddedEntity(array &$parent, $key, Entity $entity, $depth = 0)
     {
-        $rendered = $this->renderEntity($entity);
+        $rendered = $this->renderEntity($entity, true, $depth + 1);
         if (!isset($parent['_embedded'])) {
             $parent['_embedded'] = array();
         }
@@ -1033,9 +1046,9 @@ class Hal extends AbstractHelper implements
      * @param  string $key
      * @param  Collection $collection
      */
-    protected function extractEmbeddedCollection(array &$parent, $key, Collection $collection)
+    protected function extractEmbeddedCollection(array &$parent, $key, Collection $collection, $depth = 0)
     {
-        $rendered = $this->extractCollection($collection);
+        $rendered = $this->extractCollection($collection, $depth + 1);
         if (!isset($parent['_embedded'])) {
             $parent['_embedded'] = array();
         }
@@ -1051,7 +1064,7 @@ class Hal extends AbstractHelper implements
      * @param  Collection $halCollection
      * @return array
      */
-    protected function extractCollection(Collection $halCollection)
+    protected function extractCollection(Collection $halCollection, $depth = 0)
     {
         $collection           = array();
         $events               = $this->getEventManager();
@@ -1080,7 +1093,7 @@ class Hal extends AbstractHelper implements
             }
 
             if ($entity instanceof Entity) {
-                $collection[] = $this->renderEntity($entity, $this->getRenderCollections());
+                $collection[] = $this->renderEntity($entity, $this->getRenderCollections(), $depth + 1);
                 continue;
             }
 
@@ -1094,11 +1107,11 @@ class Hal extends AbstractHelper implements
                 }
 
                 if ($value instanceof Entity) {
-                    $this->extractEmbeddedEntity($entity, $key, $value);
+                    $this->extractEmbeddedEntity($entity, $key, $value, $depth + 1);
                 }
 
                 if ($value instanceof Collection) {
-                    $this->extractEmbeddedCollection($entity, $key, $value);
+                    $this->extractEmbeddedCollection($entity, $key, $value, $depth + 1);
                 }
             }
 

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -1356,4 +1356,10 @@ class HalTest extends TestCase
             }
         }
     }
+
+    public function testCircularReferenceDetection()
+    {
+        $this->setExpectedException('\ZF\Hal\Exception\CircularReferenceException');
+        $this->renderCircularEntityGraph(null);
+    }
 }

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -1369,4 +1369,12 @@ class HalTest extends TestCase
 
         $this->renderCircularEntityGraph(null);
     }
+
+    public function testMaxDepthIsResetBetweenCalls()
+    {
+        $result1 = $this->renderCircularEntityGraph(0);
+        $result2 = $this->renderCircularEntityGraph(1);
+
+        $this->assertNotEquals(count($result1, COUNT_RECURSIVE), count($result2, COUNT_RECURSIVE));
+    }
 }

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -1359,7 +1359,11 @@ class HalTest extends TestCase
 
     public function testCircularReferenceDetection()
     {
-        $this->setExpectedException('\ZF\Hal\Exception\CircularReferenceException');
+        $this->setExpectedException(
+            'ZF\Hal\Exception\CircularReferenceException',
+            'Circular reference detected: ZFTest\Hal\Plugin\TestAsset\Entity -> ZFTest\Hal\Plugin\TestAsset\EmbeddedEntityWithBackReference -> ZFTest\Hal\Plugin\TestAsset\Entity'
+        );
+
         $this->renderCircularEntityGraph(null);
     }
 }

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -1250,6 +1250,7 @@ class HalTest extends TestCase
         $this->plugin->setMetadataMap($metadata);
 
         $rendered = $this->plugin->renderEntity($entity);
+
         $this->assertRelationalLinkContains('/resource/foo', 'self', $rendered);
 
         $this->assertArrayHasKey('_embedded', $rendered);
@@ -1259,12 +1260,16 @@ class HalTest extends TestCase
 
         $first = $embed['first_child'];
         $this->assertInternalType('array', $first);
+        $this->assertArrayHasKey('id', $first);
         $this->assertRelationalLinkContains('/embedded/bar', 'self', $first);
         $this->assertArrayHasKey('_embedded', $first);
 
         $childEmbed = $first['_embedded'];
         $this->assertArrayHasKey('parent', $childEmbed);
         $backreference = $embed['first_child']['_embedded']['parent'];
+        $this->assertArrayHasKey('id', $backreference);
+        $this->assertArrayHasKey('name', $backreference);
         $this->assertArrayNotHasKey('_embedded', $backreference);
+        $this->assertArrayNotHasKey('first_child', $backreference);
     }
 }

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -7,8 +7,6 @@
 namespace ZFTest\Hal\Plugin;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use RecursiveArrayIterator;
-use RecursiveIteratorIterator;
 use ReflectionObject;
 use Zend\Http\Request;
 use Zend\Mvc\Router\Http\TreeRouteStack;

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -1333,6 +1333,8 @@ class HalTest extends TestCase
         $halCollection = $this->plugin->createCollection($collection);
         $rendered = $this->plugin->renderCollection($halCollection);
 
+        print_r($rendered);
+
         $this->assertRelationalLinkContains('/contacts', 'self', $rendered);
         $this->assertArrayHasKey('_embedded', $rendered);
         $this->assertInternalType('array', $rendered['_embedded']);
@@ -1346,11 +1348,14 @@ class HalTest extends TestCase
                 $this->assertArrayHasKey('_embedded', $entity);
                 $this->assertCount(1, $entity['_embedded']);
                 $this->assertArrayHasKey('first_child', $entity['_embedded']);
-                $this->assertCount(1, $entity['_embedded']['first_child']);
+                $child = $entity['_embedded']['first_child'];
                 $this->assertRelationalLinkContains('/embedded/bar', 'self', $child);
+                $this->assertCount(1, $child['_embedded']);
+                $this->assertArrayHasKey('parent', $child['_embedded']);
+                $backReference = $child['_embedded']['parent'];
+                $this->assertCount(1, $backReference);
+                $this->assertRelationalLinkContains('/resource/foo', 'self', $backReference);
             }
         }
-
-        print_r($rendered);
     }
 }

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -1260,10 +1260,7 @@ class HalTest extends TestCase
                 null,
                 array(
                     'class'   => 'ZF\Hal\Exception\CircularReferenceException',
-                    'message' => 'Circular reference detected: '
-                        . 'ZFTest\Hal\Plugin\TestAsset\Entity -> '
-                        . 'ZFTest\Hal\Plugin\TestAsset\EmbeddedEntityWithBackReference -> '
-                        . 'ZFTest\Hal\Plugin\TestAsset\Entity',
+                    'message' => 'Circular reference detected in \'ZFTest\Hal\Plugin\TestAsset\Entity\'',
                 )
             ),
             array(
@@ -1423,7 +1420,7 @@ class HalTest extends TestCase
     {
         return array(
             array(
-                function() {
+                function () {
                     $object1 = new TestAsset\Entity('foo', 'Foo');
                     $object1->first_child  = new TestAsset\EmbeddedEntityWithBackReference('bar', $object1);
                     $object2 = new TestAsset\Entity('bar', 'Bar');
@@ -1441,11 +1438,11 @@ class HalTest extends TestCase
                 null,
                 array(
                     'class'   => 'ZF\Hal\Exception\CircularReferenceException',
-                    'message' => 'ZFTest\Hal\Plugin\TestAsset\EmbeddedEntityWithBackReference',
+                    'message' => 'Circular reference detected in \'ZFTest\Hal\Plugin\TestAsset\Entity\'',
                 )
             ),
             array(
-                function() {
+                function () {
                     $object1 = new TestAsset\Entity('foo', 'Foo');
                     $object1->first_child  = new TestAsset\EmbeddedEntityWithBackReference('bar', $object1);
                     $object2 = new TestAsset\Entity('bar', 'Bar');
@@ -1524,6 +1521,92 @@ class HalTest extends TestCase
                     'total_items' => 3,
                 ),
             ),
+            array(
+                function () {
+                    $object1 = new TestAsset\Entity('foo', 'Foo');
+                    $object2 = new TestAsset\Entity('bar', 'Bar');
+
+                    $collection = new TestAsset\Collection(array(
+                        $object1,
+                        $object2,
+                    ));
+                    $object1->first_child = $collection;
+
+                    return $collection;
+                },
+                $this->createNestedCollectionMetadataMap(),
+                null,
+                array(
+                    'class'   => 'ZF\Hal\Exception\CircularReferenceException',
+                    'message' => 'Circular reference detected in \'ZFTest\Hal\Plugin\TestAsset\Entity\'',
+                )
+            ),
+            array(
+                function () {
+                    $object1 = new TestAsset\Entity('foo', 'Foo');
+                    $object2 = new TestAsset\Entity('bar', 'Bar');
+
+                    $collection = new TestAsset\Collection(array(
+                        $object1,
+                        $object2,
+                    ));
+                    $object1->first_child = $collection;
+
+                    return $collection;
+                },
+                $this->createNestedCollectionMetadataMap(1),
+                array(
+                    '_links' => array(
+                        'self' => array(
+                            'href' => 'http://localhost.localdomain/contacts',
+                        ),
+                    ),
+                    '_embedded' => array(
+                        'collection' => array(
+                            array(
+                                'id'           => 'foo',
+                                'name'         => 'Foo',
+                                'second_child' => null,
+                                '_embedded'    => array(
+                                    'first_child' => array(
+                                        array(
+                                            '_links' => array(
+                                                'self' => array(
+                                                    'href' => 'http://localhost.localdomain/resource/foo',
+                                                ),
+                                            ),
+                                        ),
+                                        array(
+                                            '_links' => array(
+                                                'self' => array(
+                                                    'href' => 'http://localhost.localdomain/resource/bar',
+                                                ),
+                                            ),
+                                        )
+                                    ),
+                                ),
+                                '_links'       => array(
+                                    'self' => array(
+                                        'href' => 'http://localhost.localdomain/resource/foo',
+                                    ),
+                                ),
+                            ),
+                            array(
+                                'id'           => 'bar',
+                                'name'         => 'Bar',
+                                'first_child'  => null,
+                                'second_child' => null,
+                                '_links'       => array(
+                                    'self' => array(
+                                        'href' => 'http://localhost.localdomain/resource/bar',
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                    'total_items' => 2,
+                ),
+            )
         );
     }
 

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -1342,11 +1342,13 @@ class HalTest extends TestCase
 
         foreach ($renderedCollection as $entity) {
             $this->assertRelationalLinkContains('/resource/', 'self', $entity);
+            $this->assertArrayHasKey('id', $entity);
             if ($entity['id'] === 'foo') {
                 $this->assertArrayHasKey('_embedded', $entity);
                 $this->assertCount(1, $entity['_embedded']);
                 $this->assertArrayHasKey('first_child', $entity['_embedded']);
                 $child = $entity['_embedded']['first_child'];
+                $this->assertArrayHasKey('id', $child);
                 $this->assertRelationalLinkContains('/embedded/bar', 'self', $child);
                 $this->assertCount(1, $child['_embedded']);
                 $this->assertArrayHasKey('parent', $child['_embedded']);

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -1333,8 +1333,6 @@ class HalTest extends TestCase
         $halCollection = $this->plugin->createCollection($collection);
         $rendered = $this->plugin->renderCollection($halCollection);
 
-        print_r($rendered);
-
         $this->assertRelationalLinkContains('/contacts', 'self', $rendered);
         $this->assertArrayHasKey('_embedded', $rendered);
         $this->assertInternalType('array', $rendered['_embedded']);

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -1237,6 +1237,7 @@ class HalTest extends TestCase
                 'route_name' => 'hostname/resource',
                 'route_identifier_name' => 'id',
                 'entity_identifier_name' => 'id',
+                'max_depth' => 2,
             ),
             'ZFTest\Hal\Plugin\TestAsset\EmbeddedEntityWithBackReference' => array(
                 'hydrator' => 'Zend\Stdlib\Hydrator\ObjectProperty',
@@ -1259,5 +1260,11 @@ class HalTest extends TestCase
         $first = $embed['first_child'];
         $this->assertInternalType('array', $first);
         $this->assertRelationalLinkContains('/embedded/bar', 'self', $first);
+        $this->assertArrayHasKey('_embedded', $first);
+
+        $childEmbed = $first['_embedded'];
+        $this->assertArrayHasKey('parent', $childEmbed);
+        $backreference = $embed['first_child']['_embedded']['parent'];
+        $this->assertArrayNotHasKey('_embedded', $backreference);
     }
 }

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -1361,7 +1361,10 @@ class HalTest extends TestCase
     {
         $this->setExpectedException(
             'ZF\Hal\Exception\CircularReferenceException',
-            'Circular reference detected: ZFTest\Hal\Plugin\TestAsset\Entity -> ZFTest\Hal\Plugin\TestAsset\EmbeddedEntityWithBackReference -> ZFTest\Hal\Plugin\TestAsset\Entity'
+            'Circular reference detected: '
+            . 'ZFTest\Hal\Plugin\TestAsset\Entity -> '
+            . 'ZFTest\Hal\Plugin\TestAsset\EmbeddedEntityWithBackReference -> '
+            . 'ZFTest\Hal\Plugin\TestAsset\Entity'
         );
 
         $this->renderCircularEntityGraph(null);

--- a/test/Plugin/TestAsset/EmbeddedEntityWithBackReference.php
+++ b/test/Plugin/TestAsset/EmbeddedEntityWithBackReference.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Hal\Plugin\TestAsset;
+
+class EmbeddedEntityWithBackReference
+{
+    public $id;
+    public $parent;
+
+    public function __construct($id, Entity $parent)
+    {
+        $this->id   = $id;
+        $this->parent = $parent;
+    }
+}


### PR DESCRIPTION
This PR is a follow up of #66 and #67 

The `max_depth` param introduced now follows this semantic:

By default this value is `null`. Any circular reference between entities will now end up in a `ZF\Hal\Exception\CircularReferenceException` being thrown, rather than a nasty infinite loop.

When `max_depth` is set and the value is reached, one last iteration of embedded entities is rendered, but only consisting of self links, no data is actually rendered. This means that a value of `0` is actually different from setting `render_embedded_entities` to `false` in the `renderer` configuration key of the plugin, because it will render the links of the embedded entities in the first level.