### PR TITLE
Added use Countable at top of Class

### DIFF
--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -34,6 +34,7 @@ use ZF\Hal\Link\LinkCollection;
 use ZF\Hal\Link\LinkCollectionAwareInterface;
 use ZF\Hal\Metadata\Metadata;
 use ZF\Hal\Metadata\MetadataMap;
+use Countable;
 
 /**
  * Generate links for use with HAL payloads


### PR DESCRIPTION
Added `use Countable` at the top of the Hal plugin so that `total_items` are counted for collections that are an instance of `Countable`.