### PR TITLE
Fix bug causing duplicate links when entity contains links and is rendered twice

### DIFF
--- a/src/Link/LinkCollection.php
+++ b/src/Link/LinkCollection.php
@@ -116,4 +116,15 @@ class LinkCollection implements Countable, IteratorAggregate
         unset($this->links[$relation]);
         return true;
     }
+    
+    /**
+     * Remove all links
+     *
+     * @return self
+     */
+    public function clear()
+    {
+        $this->links = array();
+        return $this;
+    }
 }

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -552,6 +552,10 @@ class Hal extends AbstractHelper implements
         $this->getEventManager()->trigger(__FUNCTION__, $this, array('entity' => $halEntity));
         $entity      = $halEntity->entity;
         $entityLinks = $halEntity->getLinks();
+
+        // $entityLinks is modified during rendering, so keep a backup to prevent side effects.
+        $entityLinksBackup = clone($entityLinks);
+
         $metadataMap = $this->getMetadataMap();
 
         if (is_object($entity)) {
@@ -615,6 +619,12 @@ class Hal extends AbstractHelper implements
 
         if (isset($entityHash)) {
             unset($this->entityHashStack[$entityHash]);
+        }
+
+        // Restore $entityLinks to its original state
+        $entityLinks->clear();
+        foreach ($entityLinksBackup as $link) {
+            $entityLinks->add($link);
         }
 
         return $entity;

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -879,6 +879,25 @@ class HalTest extends TestCase
         $this->assertEquals('closure-param', $params['test-2']);
     }
 
+    public function testRenderEntityTwice()
+    {
+        $link = new Link('resource');
+        $link->setRoute('resource', array('id' => 'user'));
+
+        $entity = new Entity(
+            (object) array(
+                'id'   => 'user',
+                'name' => 'matthew',
+                'resource' => $link,
+            ),
+            'user'
+        );
+
+        $rendered1 = $this->plugin->renderEntity($entity);
+        $rendered2 = $this->plugin->renderEntity($entity);
+        $this->assertEquals($rendered1, $rendered2);
+    }
+
     /**
      * @group 79
      */


### PR DESCRIPTION
When an entity contains a link, the link is added to the collection upon each rendering. This PR fixes that issue.