### PR TITLE
Do not force self links [Fixes #80] 

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Each class in the metadata map may contain one or more of the following configur
 - `max_depth` - integer; limit to what nesting level entities and collections are rendered; if the limit is 
   reached, only `self` links will be rendered. default value is `null`, which means no limit: if unlimited circular 
   references are detected, an exception will be thrown to avoid infinite loops.
+- `force_self_link` - boolean; set whether a self-referencing link should be automatically generated for the entity.
+  Defaults to `true` (since its recommended).
 
 The `links` property is an array of arrays, each with the following structure:
 

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -75,6 +75,14 @@ class Metadata
     protected $links = array();
 
     /**
+     * Whether to force the existance of a "self" link. The HAl specification encourages it but it is not strictly
+     * required.
+     *
+     * @var bool
+     */
+    protected $forceSelfLink = true;
+
+    /**
      * Route to use to generate a self link for this entity
      *
      * @var string
@@ -569,6 +577,28 @@ class Metadata
     public function setMaxDepth($maxDepth)
     {
         $this->maxDepth = $maxDepth;
+        return $this;
+    }
+
+    /**
+     * Returns true if this entity should be forced to have a "self" link.
+     *
+     * @return boolean
+     */
+    public function getForceSelfLink()
+    {
+        return $this->forceSelfLink;
+    }
+
+    /**
+     * Set whether to force the existance of "self" links.
+     *
+     * @param boolean $forceSelfLink A truthy value
+     * @return $this
+     */
+    public function setForceSelfLink($forceSelfLink)
+    {
+        $this->forceSelfLink = $forceSelfLink;
         return $this;
     }
 }

--- a/test/Factory/MetadataMapFactoryTest.php
+++ b/test/Factory/MetadataMapFactoryTest.php
@@ -57,12 +57,14 @@ class MetadataMapFactoryTest extends TestCase
                         'route'    => 'hostname/embedded',
                         'route_identifier_name' => 'id',
                         'entity_identifier_name' => 'id',
+                        'force_self_link' => true, // same as previous
                     ),
                     'ZFTest\Hal\Plugin\TestAsset\EmbeddedEntityWithCustomIdentifier' => array(
                         'hydrator'        => 'Zend\Stdlib\Hydrator\ObjectProperty',
                         'route'           => 'hostname/embedded_custom',
                         'route_identifier_name' => 'custom_id',
                         'entity_identifier_name' => 'custom_id',
+                        'force_self_link' => false,
                     ),
                 ),
             ),


### PR DESCRIPTION
Allow user to discretely switch off the automatic generation of "self" links for HAL Entities.

See README.md changes to easy usage.