### PR TITLE
Refactor Hal plugin by reducing his responsabilities

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -55,9 +55,11 @@ return array(
     ),
     'service_manager' => array(
         'factories' => array(
-            'ZF\Hal\JsonRenderer' => 'ZF\Hal\Factory\HalJsonRendererFactory',
-            'ZF\Hal\JsonStrategy' => 'ZF\Hal\Factory\HalJsonStrategyFactory',
-            'ZF\Hal\MetadataMap'  => 'ZF\Hal\Factory\MetadataMapFactory',
+            'ZF\Hal\HalConfig'       => 'ZF\Hal\Factory\HalConfigFactory',
+            'ZF\Hal\JsonRenderer'    => 'ZF\Hal\Factory\HalJsonRendererFactory',
+            'ZF\Hal\JsonStrategy'    => 'ZF\Hal\Factory\HalJsonStrategyFactory',
+            'ZF\Hal\MetadataMap'     => 'ZF\Hal\Factory\MetadataMapFactory',
+            'ZF\Hal\RendererOptions' => 'ZF\Hal\Factory\RendererOptionsFactory',
         ),
     ),
     'view_helpers' => array(

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -4,72 +4,72 @@
  * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
-return array(
-    'zf-hal' => array(
-        'renderer' => array(
+return [
+    'zf-hal' => [
+        'renderer' => [
             // 'default_hydrator' => 'Hydrator Service Name',
-            // 'hydrators'        => array(
+            // 'hydrators'        => [
             //     class to hydrate/hydrator service name pairs
-            // ),
-        ),
-        'metadata_map' => array(
-            // 'Class Name' => array(
+            // ],
+        ],
+        'metadata_map' => [
+            // 'Class Name' => [
             //     'hydrator'        => 'Hydrator Service Name, if a resource',
             //     'entity_identifier_name' => 'identifying field name, if a resource',
             //     'route_name'      => 'name of route for this resource',
             //     'is_collection'   => 'boolean; set to true for collections',
-            //     'links'           => array(
-            //         array(
+            //     'links'           => [
+            //         [
             //             'rel'   => 'link relation',
             //             'url'   => 'string absolute URI to use', // OR
-            //             'route' => array(
+            //             'route' => [
             //                 'name'    => 'route name for this link',
-            //                 'params'  => array( /* any route params to use for link generation */ ),
-            //                 'options' => array( /* any options to pass to the router */ ),
-            //             ),
-            //         ),
+            //                 'params'  => [ /* any route params to use for link generation */ ],
+            //                 'options' => [ /* any options to pass to the router */ ],
+            //             ],
+            //         ],
             //         repeat as needed for any additional relational links you want for this resource
-            //     ),
+            //     ],
             //     'resource_route_name' => 'route name for embedded resources of a collection',
-            //     'route_params'        => array( /* any route params to use for link generation */ ),
-            //     'route_options'       => array( /* any options to pass to the router */ ),
+            //     'route_params'        => [ /* any route params to use for link generation */ ],
+            //     'route_options'       => [ /* any options to pass to the router */ ],
             //     'url'                 => 'specific URL to use with this resource, if not using a route',
-            // ),
+            // ],
             // repeat as needed for each resource/collection type
-        ),
-        'options' => array(
+        ],
+        'options' => [
             // Needed for generate valid _link url when you use a proxy
             'use_proxy' => false,
-        ),
-    ),
+        ],
+    ],
     // Creates a "HalJson" selector for zfcampus/zf-content-negotiation
-    'zf-content-negotiation' => array(
-        'selectors' => array(
-            'HalJson' => array(
-                'ZF\Hal\View\HalJsonModel' => array(
+    'zf-content-negotiation' => [
+        'selectors' => [
+            'HalJson' => [
+                'ZF\Hal\View\HalJsonModel' => [
                     'application/json',
                     'application/*+json',
-                ),
-            ),
-        ),
-    ),
-    'service_manager' => array(
-        'factories' => array(
+                ],
+            ],
+        ],
+    ],
+    'service_manager' => [
+        'factories' => [
             'ZF\Hal\HalConfig'       => 'ZF\Hal\Factory\HalConfigFactory',
             'ZF\Hal\JsonRenderer'    => 'ZF\Hal\Factory\HalJsonRendererFactory',
             'ZF\Hal\JsonStrategy'    => 'ZF\Hal\Factory\HalJsonStrategyFactory',
             'ZF\Hal\MetadataMap'     => 'ZF\Hal\Factory\MetadataMapFactory',
             'ZF\Hal\RendererOptions' => 'ZF\Hal\Factory\RendererOptionsFactory',
-        ),
-    ),
-    'view_helpers' => array(
-        'factories' => array(
+        ],
+    ],
+    'view_helpers' => [
+        'factories' => [
             'Hal' => 'ZF\Hal\Factory\HalViewHelperFactory',
-        ),
-    ),
-    'controller_plugins' => array(
-        'factories' => array(
+        ],
+    ],
+    'controller_plugins' => [
+        'factories' => [
             'Hal' => 'ZF\Hal\Factory\HalControllerPluginFactory',
-        ),
-    ),
-);
+        ],
+    ],
+];

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,6 +16,7 @@
     </rule>
 
     <!-- Paths to check -->
+    <file>config</file>
     <file>src</file>
     <file>test</file>
 </ruleset>

--- a/src/EntityHydratorManager.php
+++ b/src/EntityHydratorManager.php
@@ -27,7 +27,7 @@ class EntityHydratorManager
      *
      * @var array
      */
-    protected $hydratorMap = array();
+    protected $hydratorMap = [];
 
     /**
      * Default hydrator to use if no hydrator found for a specific entity class.

--- a/src/EntityHydratorManager.php
+++ b/src/EntityHydratorManager.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Hal;
+
+use Zend\Stdlib\Extractor\ExtractionInterface;
+use Zend\Stdlib\Hydrator\HydratorPluginManager;
+use ZF\Hal\Metadata\MetadataMap;
+
+class EntityHydratorManager
+{
+    /**
+     * @var HydratorPluginManager
+     */
+    protected $hydrators;
+
+    /**
+     * @var MetadataMap
+     */
+    protected $metadataMap;
+
+    /**
+     * Map of class name/(hydrator instance|name) pairs
+     *
+     * @var array
+     */
+    protected $hydratorMap = array();
+
+    /**
+     * Default hydrator to use if no hydrator found for a specific entity class.
+     *
+     * @var ExtractionInterface
+     */
+    protected $defaultHydrator;
+
+    /**
+     * @param HydratorPluginManager $hydrators
+     * @param MetadataMap $map
+     */
+    public function __construct(HydratorPluginManager $hydrators, MetadataMap $map)
+    {
+        $this->hydrators   = $hydrators;
+        $this->metadataMap = $map;
+    }
+
+    /**
+     * @return HydratorPluginManager
+     */
+    public function getHydratorManager()
+    {
+        return $this->hydrators;
+    }
+
+    /**
+     * Map an entity class to a specific hydrator instance
+     *
+     * @param  string $class
+     * @param  ExtractionInterface $hydrator
+     * @return self
+     */
+    public function addHydrator($class, $hydrator)
+    {
+        if (!$hydrator instanceof ExtractionInterface) {
+            $hydrator = $this->hydrators->get($hydrator);
+        }
+
+        $filteredClass = strtolower($class);
+        $this->hydratorMap[$filteredClass] = $hydrator;
+        return $this;
+    }
+
+    /**
+     * Set the default hydrator to use if none specified for a class.
+     *
+     * @param  ExtractionInterface $hydrator
+     * @return self
+     */
+    public function setDefaultHydrator(ExtractionInterface $hydrator)
+    {
+        $this->defaultHydrator = $hydrator;
+        return $this;
+    }
+
+    /**
+     * Retrieve a hydrator for a given entity
+     *
+     * If the entity has a mapped hydrator, returns that hydrator. If not, and
+     * a default hydrator is present, the default hydrator is returned.
+     * Otherwise, a boolean false is returned.
+     *
+     * @param  object $entity
+     * @return ExtractionInterface|false
+     */
+    public function getHydratorForEntity($entity)
+    {
+        $class = get_class($entity);
+        $classLower = strtolower($class);
+
+        if (isset($this->hydratorMap[$classLower])) {
+            return $this->hydratorMap[$classLower];
+        }
+
+        if ($this->metadataMap->has($entity)) {
+            $metadata = $this->metadataMap->get($class);
+            $hydrator = $metadata->getHydrator();
+            if ($hydrator instanceof ExtractionInterface) {
+                $this->addHydrator($class, $hydrator);
+                return $hydrator;
+            }
+        }
+
+        if ($this->defaultHydrator instanceof ExtractionInterface) {
+            return $this->defaultHydrator;
+        }
+
+        return false;
+    }
+}

--- a/src/Extractor/EntityExtractor.php
+++ b/src/Extractor/EntityExtractor.php
@@ -35,7 +35,7 @@ class EntityExtractor implements ExtractionInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function extract($entity)
     {
@@ -54,7 +54,9 @@ class EntityExtractor implements ExtractionInterface
 
         if ($hydrator) {
             return $hydrator->extract($entity);
-        } elseif ($entity instanceof JsonSerializable) {
+        }
+
+        if ($entity instanceof JsonSerializable) {
             return $entity->jsonSerialize();
         }
 

--- a/src/Extractor/EntityExtractor.php
+++ b/src/Extractor/EntityExtractor.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Hal\Extractor;
+
+use JsonSerializable;
+use SplObjectStorage;
+use Zend\Stdlib\Extractor\ExtractionInterface;
+use ZF\Hal\EntityHydratorManager;
+
+class EntityExtractor implements ExtractionInterface
+{
+    /**
+     * @var EntityHydratorManager
+     */
+    protected $entityHydratorManager;
+
+    /**
+     * Map of entities to their ZF\Hal\Entity serializations
+     *
+     * @var SplObjectStorage
+     */
+    protected $serializedEntities;
+
+    /**
+     * @param EntityHydratorManager $entityHydratorManager
+     */
+    public function __construct(EntityHydratorManager $entityHydratorManager)
+    {
+        $this->entityHydratorManager = $entityHydratorManager;
+        $this->serializedEntities    = new SplObjectStorage();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function extract($entity)
+    {
+        if (isset($this->serializedEntities[$entity])) {
+            return $this->serializedEntities[$entity];
+        }
+
+        $array    = false;
+        $hydrator = $this->entityHydratorManager->getHydratorForEntity($entity);
+
+        if ($hydrator) {
+            $array = $hydrator->extract($entity);
+        }
+
+        if (false === $array && $entity instanceof JsonSerializable) {
+            $array = $entity->jsonSerialize();
+        }
+
+        if (false === $array) {
+            $array = get_object_vars($entity);
+        }
+
+        $this->serializedEntities[$entity] = $array;
+
+        return $array;
+    }
+}

--- a/src/Extractor/EntityExtractor.php
+++ b/src/Extractor/EntityExtractor.php
@@ -43,23 +43,21 @@ class EntityExtractor implements ExtractionInterface
             return $this->serializedEntities[$entity];
         }
 
-        $array    = false;
+        $this->serializedEntities[$entity] = $this->extractEntity($entity);
+
+        return $this->serializedEntities[$entity];
+    }
+
+    private function extractEntity($entity)
+    {
         $hydrator = $this->entityHydratorManager->getHydratorForEntity($entity);
 
         if ($hydrator) {
-            $array = $hydrator->extract($entity);
+            return $hydrator->extract($entity);
+        } elseif ($entity instanceof JsonSerializable) {
+            return $entity->jsonSerialize();
         }
 
-        if (false === $array && $entity instanceof JsonSerializable) {
-            $array = $entity->jsonSerialize();
-        }
-
-        if (false === $array) {
-            $array = get_object_vars($entity);
-        }
-
-        $this->serializedEntities[$entity] = $array;
-
-        return $array;
+        return get_object_vars($entity);
     }
 }

--- a/src/Factory/HalConfigFactory.php
+++ b/src/Factory/HalConfigFactory.php
@@ -17,12 +17,12 @@ class HalConfigFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $config = array();
+        $config = [];
         if ($serviceLocator->has('config')) {
             $config = $serviceLocator->get('config');
         }
 
-        $halConfig = array();
+        $halConfig = [];
         if (isset($config['zf-hal']) && is_array($config['zf-hal'])) {
             $halConfig = $config['zf-hal'];
         }

--- a/src/Factory/HalConfigFactory.php
+++ b/src/Factory/HalConfigFactory.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Hal\Factory;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class HalConfigFactory implements FactoryInterface
+{
+    /**
+     * @param  ServiceLocatorInterface $serviceLocator
+     * @return array
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $config = array();
+        if ($serviceLocator->has('config')) {
+            $config = $serviceLocator->get('config');
+        }
+
+        $halConfig = array();
+        if (isset($config['zf-hal']) && is_array($config['zf-hal'])) {
+            $halConfig = $config['zf-hal'];
+        }
+
+        return $halConfig;
+    }
+}

--- a/src/Factory/HalViewHelperFactory.php
+++ b/src/Factory/HalViewHelperFactory.php
@@ -22,15 +22,18 @@ class HalViewHelperFactory implements FactoryInterface
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         $services        = $serviceLocator->getServiceLocator();
-        $config          = $services->get('Config');
+        $halConfig       = $services->get('ZF\Hal\HalConfig');
+        /* @var $rendererOptions \ZF\Hal\RendererOptions */
+        $rendererOptions = $services->get('ZF\Hal\RendererOptions');
         $metadataMap     = $services->get('ZF\Hal\MetadataMap');
         $hydrators       = $metadataMap->getHydratorManager();
 
         $serverUrlHelper = $serviceLocator->get('ServerUrl');
-        if (isset($config['zf-hal']['options']['use_proxy'])) {
-            $serverUrlHelper->setUseProxy($config['zf-hal']['options']['use_proxy']);
+        if (isset($halConfig['options']['use_proxy'])) {
+            $serverUrlHelper->setUseProxy($halConfig['options']['use_proxy']);
         }
-        $urlHelper       = $serviceLocator->get('Url');
+
+        $urlHelper = $serviceLocator->get('Url');
 
         $helper = new Plugin\Hal($hydrators);
         $helper
@@ -42,43 +45,25 @@ class HalViewHelperFactory implements FactoryInterface
         $linkCollectionExtractor = new LinkCollectionExtractor($linkExtractor);
         $helper->setLinkCollectionExtractor($linkCollectionExtractor);
 
-        if (isset($config['zf-hal'])
-            && isset($config['zf-hal']['renderer'])
-        ) {
-            $config = $config['zf-hal']['renderer'];
-
-            if (isset($config['default_hydrator'])) {
-                $hydratorServiceName = $config['default_hydrator'];
-
-                if (!$hydrators->has($hydratorServiceName)) {
-                    throw new Exception\DomainException(sprintf(
-                        'Cannot locate default hydrator by name "%s" via the HydratorManager',
-                        $hydratorServiceName
-                    ));
-                }
-
-                $hydrator = $hydrators->get($hydratorServiceName);
-                $helper->setDefaultHydrator($hydrator);
+        $defaultHydrator = $rendererOptions->getDefaultHydrator();
+        if ($defaultHydrator) {
+            if (!$hydrators->has($defaultHydrator)) {
+                throw new Exception\DomainException(sprintf(
+                    'Cannot locate default hydrator by name "%s" via the HydratorManager',
+                    $defaultHydrator
+                ));
             }
 
-            if (isset($config['render_embedded_resources'])) {
-                $helper->setRenderEmbeddedEntities($config['render_embedded_resources']);
-            }
+            $hydrator = $hydrators->get($defaultHydrator);
+            $helper->setDefaultHydrator($hydrator);
+        }
 
-            if (isset($config['render_embedded_entities'])) {
-                $helper->setRenderEmbeddedEntities($config['render_embedded_entities']);
-            }
+        $helper->setRenderEmbeddedEntities($rendererOptions->getRenderEmbeddedEntities());
+        $helper->setRenderCollections($rendererOptions->getRenderEmbeddedCollections());
 
-            if (isset($config['render_collections'])) {
-                $helper->setRenderCollections($config['render_collections']);
-            }
-
-            if (isset($config['hydrators']) && is_array($config['hydrators'])) {
-                $hydratorMap = $config['hydrators'];
-                foreach ($hydratorMap as $class => $hydratorServiceName) {
-                    $helper->addHydrator($class, $hydratorServiceName);
-                }
-            }
+        $hydratorMap = $rendererOptions->getHydrators();
+        foreach ($hydratorMap as $class => $hydratorServiceName) {
+            $helper->addHydrator($class, $hydratorServiceName);
         }
 
         return $helper;

--- a/src/Factory/MetadataMapFactory.php
+++ b/src/Factory/MetadataMapFactory.php
@@ -19,10 +19,7 @@ class MetadataMapFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $config = [];
-        if ($serviceLocator->has('config')) {
-            $config = $serviceLocator->get('config');
-        }
+        $config = $serviceLocator->get('ZF\Hal\HalConfig');
 
         if ($serviceLocator->has('HydratorManager')) {
             $hydrators = $serviceLocator->get('HydratorManager');
@@ -31,11 +28,8 @@ class MetadataMapFactory implements FactoryInterface
         }
 
         $map = [];
-        if (isset($config['zf-hal'])
-            && isset($config['zf-hal']['metadata_map'])
-            && is_array($config['zf-hal']['metadata_map'])
-        ) {
-            $map = $config['zf-hal']['metadata_map'];
+        if (isset($config['metadata_map']) && is_array($config['metadata_map'])) {
+            $map = $config['metadata_map'];
         }
 
         return new Metadata\MetadataMap($map, $hydrators);

--- a/src/Factory/RendererOptionsFactory.php
+++ b/src/Factory/RendererOptionsFactory.php
@@ -20,7 +20,7 @@ class RendererOptionsFactory implements FactoryInterface
     {
         $config = $serviceLocator->get('ZF\Hal\HalConfig');
 
-        $rendererConfig = array();
+        $rendererConfig = [];
         if (isset($config['renderer']) && is_array($config['renderer'])) {
             $rendererConfig = $config['renderer'];
         }

--- a/src/Factory/RendererOptionsFactory.php
+++ b/src/Factory/RendererOptionsFactory.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Hal\Factory;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZF\Hal\RendererOptions;
+
+class RendererOptionsFactory implements FactoryInterface
+{
+    /**
+     * @param  ServiceLocatorInterface $serviceLocator
+     * @return RendererOptions
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $config = $serviceLocator->get('ZF\Hal\HalConfig');
+
+        $rendererConfig = array();
+        if (isset($config['renderer']) && is_array($config['renderer'])) {
+            $rendererConfig = $config['renderer'];
+        }
+
+        if (isset($rendererConfig['render_embedded_resources'])
+            && !isset($rendererConfig['render_embedded_entities'])
+        ) {
+            $rendererConfig['render_embedded_entities'] = $rendererConfig['render_embedded_resources'];
+        }
+
+        return new RendererOptions($rendererConfig);
+    }
+}

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -1238,7 +1238,7 @@ class Hal extends AbstractHelper implements
      */
     protected function convertEntityToArray($entity)
     {
-        return $this->getResourceFactory()->convertEntityToArray($entity);
+        return $this->getEntityExtractor()->extract($entity);
     }
 
     /**

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -24,6 +24,7 @@ use ZF\ApiProblem\ApiProblem;
 use ZF\Hal\Collection;
 use ZF\Hal\Entity;
 use ZF\Hal\EntityHydratorManager;
+use ZF\Hal\Extractor\EntityExtractor;
 use ZF\Hal\Exception;
 use ZF\Hal\Extractor\LinkCollectionExtractorInterface;
 use ZF\Hal\Link\Link;
@@ -55,6 +56,11 @@ class Hal extends AbstractHelper implements
      * @var EntityHydratorManager
      */
     protected $entityHydratorManager;
+
+    /**
+     * @var EntityExtractor
+     */
+    protected $entityExtractor;
 
     /**
      * Boolean to render embedded entities or just include _embedded data
@@ -201,7 +207,7 @@ class Hal extends AbstractHelper implements
         if (!$this->resourceFactory instanceof ResourceFactory) {
             $this->resourceFactory = new ResourceFactory(
                 $this->getEntityHydratorManager(),
-                $this->getMetadataMap()
+                $this->getEntityExtractor()
             );
         }
         return $this->resourceFactory;
@@ -239,6 +245,30 @@ class Hal extends AbstractHelper implements
     public function setEntityHydratorManager(EntityHydratorManager $manager)
     {
         $this->entityHydratorManager = $manager;
+        return $this;
+    }
+
+    /**
+     * @return EntityExtractor
+     */
+    public function getEntityExtractor()
+    {
+        if (!$this->entityExtractor instanceof EntityExtractor) {
+            $this->entityExtractor = new EntityExtractor(
+                $this->getEntityHydratorManager()
+            );
+        }
+
+        return $this->entityExtractor;
+    }
+
+    /**
+     * @param  EntityExtractor $extractor
+     * @return self
+     */
+    public function setEntityExtractor(EntityExtractor $extractor)
+    {
+        $this->entityExtractor = $extractor;
         return $this;
     }
 
@@ -604,7 +634,7 @@ class Hal extends AbstractHelper implements
         }
 
         if (!is_array($entity)) {
-            $entity = $this->getResourceFactory()->convertEntityToArray($entity);
+            $entity = $this->getEntityExtractor()->extract($entity);
         }
 
         foreach ($entity as $key => $value) {
@@ -1094,7 +1124,7 @@ class Hal extends AbstractHelper implements
             }
 
             if (!is_array($entity)) {
-                $entity = $this->getResourceFactory()->convertEntityToArray($entity);
+                $entity = $this->getEntityExtractor()->extract($entity);
             }
 
             foreach ($entity as $key => $value) {

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -1260,7 +1260,11 @@ class Hal extends AbstractHelper implements
         $relation = 'self'
     ) {
         return $this->getResourceFactory()->marshalLinkFromMetadata(
-            $metadata, $object, $id, $routeIdentifierName, $relation
+            $metadata,
+            $object,
+            $id,
+            $routeIdentifierName,
+            $relation
         );
     }
 

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -7,10 +7,7 @@
 namespace ZF\Hal\Plugin;
 
 use ArrayObject;
-use Closure;
 use Countable;
-use JsonSerializable;
-use SplObjectStorage;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\EventManagerAwareInterface;
 use Zend\EventManager\EventManagerInterface;
@@ -26,6 +23,7 @@ use Zend\View\Helper\Url;
 use ZF\ApiProblem\ApiProblem;
 use ZF\Hal\Collection;
 use ZF\Hal\Entity;
+use ZF\Hal\EntityHydratorManager;
 use ZF\Hal\Exception;
 use ZF\Hal\Extractor\LinkCollectionExtractorInterface;
 use ZF\Hal\Link\Link;
@@ -34,6 +32,7 @@ use ZF\Hal\Link\LinkCollectionAwareInterface;
 use ZF\Hal\Metadata\Metadata;
 use ZF\Hal\Metadata\MetadataMap;
 use ZF\Hal\Resource;
+use ZF\Hal\ResourceFactory;
 
 /**
  * Generate links for use with HAL payloads
@@ -48,11 +47,14 @@ class Hal extends AbstractHelper implements
     protected $controller;
 
     /**
-     * Default hydrator to use if no hydrator found for a specific entity class.
-     *
-     * @var ExtractionInterface
+     * @var ResourceFactory
      */
-    protected $defaultHydrator;
+    protected $resourceFactory;
+
+    /**
+     * @var EntityHydratorManager
+     */
+    protected $entityHydratorManager;
 
     /**
      * Boolean to render embedded entities or just include _embedded data
@@ -69,23 +71,9 @@ class Hal extends AbstractHelper implements
     protected $renderCollections = true;
 
     /**
-     * Map of entities to their ZF\Hal\Entity serializations
-     *
-     * @var SplObjectStorage
-     */
-    protected $serializedEntities;
-
-    /**
      * @var EventManagerInterface
      */
     protected $events;
-
-    /**
-     * Map of class name/(hydrator instance|name) pairs
-     *
-     * @var array
-     */
-    protected $hydratorMap = [];
 
     /**
      * @var HydratorPluginManager
@@ -128,8 +116,6 @@ class Hal extends AbstractHelper implements
             $hydrators = new HydratorPluginManager();
         }
         $this->hydrators = $hydrators;
-
-        $this->serializedEntities = new SplObjectStorage();
     }
 
     /**
@@ -208,6 +194,55 @@ class Hal extends AbstractHelper implements
     }
 
     /**
+     * @return ResourceFactory
+     */
+    public function getResourceFactory()
+    {
+        if (!$this->resourceFactory instanceof ResourceFactory) {
+            $this->resourceFactory = new ResourceFactory(
+                $this->getEntityHydratorManager(),
+                $this->getMetadataMap()
+            );
+        }
+        return $this->resourceFactory;
+    }
+
+    /**
+     * @param  ResourceFactory $factory
+     * @return self
+     */
+    public function setResourceFactory(ResourceFactory $factory)
+    {
+        $this->resourceFactory = $factory;
+        return $this;
+    }
+
+    /**
+     * @return EntityHydratorManager
+     */
+    public function getEntityHydratorManager()
+    {
+        if (!$this->entityHydratorManager instanceof EntityHydratorManager) {
+            $this->entityHydratorManager = new EntityHydratorManager(
+                $this->hydrators,
+                $this->getMetadataMap()
+            );
+        }
+
+        return $this->entityHydratorManager;
+    }
+
+    /**
+     * @param  EntityHydratorManager $manager
+     * @return self
+     */
+    public function setEntityHydratorManager(EntityHydratorManager $manager)
+    {
+        $this->entityHydratorManager = $manager;
+        return $this;
+    }
+
+    /**
      * @return HydratorPluginManager
      */
     public function getHydratorManager()
@@ -216,8 +251,6 @@ class Hal extends AbstractHelper implements
     }
 
     /**
-     * Retrieve the metadata map
-     *
      * @return MetadataMap
      */
     public function getMetadataMap()
@@ -225,12 +258,11 @@ class Hal extends AbstractHelper implements
         if (!$this->metadataMap instanceof MetadataMap) {
             $this->setMetadataMap(new MetadataMap());
         }
+
         return $this->metadataMap;
     }
 
     /**
-     * Set the metadata map
-     *
      * @param  MetadataMap $map
      * @return self
      */
@@ -287,12 +319,7 @@ class Hal extends AbstractHelper implements
      */
     public function addHydrator($class, $hydrator)
     {
-        if (!$hydrator instanceof ExtractionInterface) {
-            $hydrator = $this->hydrators->get($hydrator);
-        }
-
-        $class = strtolower($class);
-        $this->hydratorMap[$class] = $hydrator;
+        $this->getEntityHydratorManager()->addHydrator($class, $hydrator);
         return $this;
     }
 
@@ -304,7 +331,7 @@ class Hal extends AbstractHelper implements
      */
     public function setDefaultHydrator(ExtractionInterface $hydrator)
     {
-        $this->defaultHydrator = $hydrator;
+        $this->getEntityHydratorManager()->setDefaultHydrator($hydrator);
         return $this;
     }
 
@@ -417,28 +444,7 @@ class Hal extends AbstractHelper implements
      */
     public function getHydratorForEntity($entity)
     {
-        $class = get_class($entity);
-        $classLower = strtolower($class);
-
-        if (isset($this->hydratorMap[$classLower])) {
-            return $this->hydratorMap[$classLower];
-        }
-
-        $metadataMap = $this->getMetadataMap();
-        if ($metadataMap->has($entity)) {
-            $metadata = $metadataMap->get($class);
-            $hydrator = $metadata->getHydrator();
-            if ($hydrator instanceof ExtractionInterface) {
-                $this->addHydrator($class, $hydrator);
-                return $hydrator;
-            }
-        }
-
-        if ($this->defaultHydrator instanceof ExtractionInterface) {
-            return $this->defaultHydrator;
-        }
-
-        return false;
+        return $this->getEntityHydratorManager()->getHydratorForEntity($entity);
     }
 
     /**
@@ -598,12 +604,12 @@ class Hal extends AbstractHelper implements
         }
 
         if (!is_array($entity)) {
-            $entity = $this->convertEntityToArray($entity);
+            $entity = $this->getResourceFactory()->convertEntityToArray($entity);
         }
 
         foreach ($entity as $key => $value) {
             if (is_object($value) && $metadataMap->has($value)) {
-                $value = $this->createEntityFromMetadata(
+                $value = $this->getResourceFactory()->createEntityFromMetadata(
                     $value,
                     $metadataMap->get($value),
                     $this->getRenderEmbeddedEntities()
@@ -757,43 +763,14 @@ class Hal extends AbstractHelper implements
      * @param  Metadata $metadata
      * @param  bool $renderEmbeddedEntities
      * @return Entity|Collection
-     * @throws Exception\RuntimeException
      */
     public function createEntityFromMetadata($object, Metadata $metadata, $renderEmbeddedEntities = true)
     {
-        if ($metadata->isCollection()) {
-            return $this->createCollectionFromMetadata($object, $metadata);
-        }
-
-        $data = $this->convertEntityToArray($object);
-
-        $entityIdentifierName = $metadata->getEntityIdentifierName();
-        if ($entityIdentifierName && ! isset($data[$entityIdentifierName])) {
-            throw new Exception\RuntimeException(sprintf(
-                'Unable to determine entity identifier for object of type "%s"; no fields matching "%s"',
-                get_class($object),
-                $entityIdentifierName
-            ));
-        }
-
-        $id = ($entityIdentifierName) ? $data[$entityIdentifierName]: null;
-
-        if (!$renderEmbeddedEntities) {
-            $object = [];
-        }
-
-        $halEntity = new Entity($object, $id);
-
-        $links = $halEntity->getLinks();
-        $this->marshalMetadataLinks($metadata, $links);
-
-        $forceSelfLink = $metadata->getForceSelfLink();
-        if ($forceSelfLink && !$links->has('self')) {
-            $link = $this->marshalLinkFromMetadata($metadata, $object, $id, $metadata->getRouteIdentifierName());
-            $links->add($link);
-        }
-
-        return $halEntity;
+        return $this->getResourceFactory()->createEntityFromMetadata(
+            $object,
+            $metadata,
+            $renderEmbeddedEntities
+        );
     }
 
     /**
@@ -828,27 +805,27 @@ class Hal extends AbstractHelper implements
     public function createEntity($entity, $route, $routeIdentifierName)
     {
         $metadataMap = $this->getMetadataMap();
-        switch (true) {
-            case (is_object($entity) && $metadataMap->has($entity)):
-                $generatedEntity = $this->createEntityFromMetadata($entity, $metadataMap->get($entity));
-                $halEntity = new Entity($entity, $generatedEntity->id);
-                $halEntity->setLinks($generatedEntity->getLinks());
-                break;
 
-            case (! $entity instanceof Entity):
-                $id = $this->getIdFromEntity($entity) ?: null;
-                $halEntity = new Entity($entity, $id);
-                break;
-
-            case ($entity instanceof Entity):
-            default:
-                $halEntity = $entity; // as is
-                break;
+        if (is_object($entity) && $metadataMap->has($entity)) {
+            $halEntity = $this->getResourceFactory()->createEntityFromMetadata(
+                $entity,
+                $metadataMap->get($entity)
+            );
+        } elseif (! $entity instanceof Entity) {
+            $id = $this->getIdFromEntity($entity) ?: null;
+            $halEntity = new Entity($entity, $id);
+        } else {
+            $halEntity = $entity;
         }
-        $metadata = (!is_array($entity) && $metadataMap->has($entity)) ? $metadataMap->get($entity) : false;
+
+        $metadata = (!is_array($entity) && $metadataMap->has($entity))
+            ? $metadataMap->get($entity)
+            : false;
+
         if (!$metadata || ($metadata && $metadata->getForceSelfLink())) {
             $this->injectSelfLink($halEntity, $route, $routeIdentifierName);
         }
+
         return $halEntity;
     }
 
@@ -863,7 +840,10 @@ class Hal extends AbstractHelper implements
     {
         $metadataMap = $this->getMetadataMap();
         if (is_object($collection) && $metadataMap->has($collection)) {
-            $collection = $this->createCollectionFromMetadata($collection, $metadataMap->get($collection));
+            $collection = $this->getResourceFactory()->createCollectionFromMetadata(
+                $collection,
+                $metadataMap->get($collection)
+            );
         }
 
         if (!$collection instanceof Collection) {
@@ -874,6 +854,7 @@ class Hal extends AbstractHelper implements
         if (!$metadata || ($metadata && $metadata->getForceSelfLink())) {
             $this->injectSelfLink($collection, $route);
         }
+
         return $collection;
     }
 
@@ -884,25 +865,7 @@ class Hal extends AbstractHelper implements
      */
     public function createCollectionFromMetadata($object, Metadata $metadata)
     {
-        $collection = new Collection($object);
-        $collection->setCollectionName($metadata->getCollectionName());
-        $collection->setCollectionRoute($metadata->getRoute());
-        $collection->setEntityRoute($metadata->getEntityRoute());
-        $collection->setRouteIdentifierName($metadata->getRouteIdentifierName());
-        $collection->setEntityIdentifierName($metadata->getEntityIdentifierName());
-
-        $links = $collection->getLinks();
-        $this->marshalMetadataLinks($metadata, $links);
-
-        $forceSelfLink = $metadata->getForceSelfLink();
-        if ($forceSelfLink && !$links->has('self')
-            && ($metadata->hasUrl() || $metadata->hasRoute())
-        ) {
-            $link = $this->marshalLinkFromMetadata($metadata, $object);
-            $links->add($link);
-        }
-
-        return $collection;
+        return $this->getResourceFactory()->createCollectionFromMetadata($object, $metadata);
     }
 
     /**
@@ -1121,7 +1084,7 @@ class Hal extends AbstractHelper implements
             $entity = $eventParams['entity'];
 
             if (is_object($entity) && $metadataMap->has($entity)) {
-                $entity = $this->createEntityFromMetadata($entity, $metadataMap->get($entity));
+                $entity = $this->getResourceFactory()->createEntityFromMetadata($entity, $metadataMap->get($entity));
             }
 
             if ($entity instanceof Entity) {
@@ -1131,12 +1094,12 @@ class Hal extends AbstractHelper implements
             }
 
             if (!is_array($entity)) {
-                $entity = $this->convertEntityToArray($entity);
+                $entity = $this->getResourceFactory()->convertEntityToArray($entity);
             }
 
             foreach ($entity as $key => $value) {
                 if (is_object($value) && $metadataMap->has($value)) {
-                    $value = $this->createEntityFromMetadata($value, $metadataMap->get($value));
+                    $value = $this->getResourceFactory()->createEntityFromMetadata($value, $metadataMap->get($value));
                 }
 
                 if ($value instanceof Entity) {
@@ -1239,45 +1202,25 @@ class Hal extends AbstractHelper implements
     /**
      * Convert an individual entity to an array
      *
+     * @deprecated
      * @param  object $entity
      * @return array
      */
     protected function convertEntityToArray($entity)
     {
-        if (isset($this->serializedEntities[$entity])) {
-            return $this->serializedEntities[$entity];
-        }
-
-        $array    = false;
-        $hydrator = $this->getHydratorForEntity($entity);
-
-        if ($hydrator) {
-            $array = $hydrator->extract($entity);
-        }
-
-        if (false === $array && $entity instanceof JsonSerializable) {
-            $array = $entity->jsonSerialize();
-        }
-
-        if (false === $array) {
-            $array = get_object_vars($entity);
-        }
-
-        $this->serializedEntities[$entity] = $array;
-
-        return $array;
+        return $this->getResourceFactory()->convertEntityToArray($entity);
     }
 
     /**
      * Creates a link object, given metadata and a resource
      *
+     * @deprecated
      * @param  Metadata $metadata
      * @param  object $object
      * @param  null|string $id
      * @param  null|string $routeIdentifierName
      * @param  string $relation
      * @return Link
-     * @throws Exception\RuntimeException
      */
     protected function marshalLinkFromMetadata(
         Metadata $metadata,
@@ -1286,56 +1229,21 @@ class Hal extends AbstractHelper implements
         $routeIdentifierName = null,
         $relation = 'self'
     ) {
-        $link = new Link($relation);
-        if ($metadata->hasUrl()) {
-            $link->setUrl($metadata->getUrl());
-            return $link;
-        }
-
-        if (!$metadata->hasRoute()) {
-            throw new Exception\RuntimeException(sprintf(
-                'Unable to create a self link for resource of type "%s"; metadata does not contain a route or a url',
-                get_class($object)
-            ));
-        }
-
-        $params = $metadata->getRouteParams();
-
-        // process any callbacks
-        foreach ($params as $key => $param) {
-            // bind to the object if supported
-            if ($param instanceof Closure
-                && version_compare(PHP_VERSION, '5.4.0') >= 0
-            ) {
-                $param = $param->bindTo($object);
-            }
-
-            // pass the object for callbacks and non-bound closures
-            if (is_callable($param)) {
-                $params[$key] = call_user_func_array($param, [$object]);
-            }
-        }
-
-        if ($routeIdentifierName) {
-            $params = array_merge($params, [$routeIdentifierName => $id]);
-        }
-
-        $link->setRoute($metadata->getRoute(), $params, $metadata->getRouteOptions());
-        return $link;
+        return $this->getResourceFactory()->marshalLinkFromMetadata(
+            $metadata, $object, $id, $routeIdentifierName, $relation
+        );
     }
 
     /**
      * Inject any links found in the metadata into the resource's link collection
      *
+     * @deprecated
      * @param  Metadata $metadata
      * @param  LinkCollection $links
      */
     protected function marshalMetadataLinks(Metadata $metadata, LinkCollection $links)
     {
-        foreach ($metadata->getLinks() as $linkData) {
-            $link = Link::factory($linkData);
-            $links->add($link);
-        }
+        $this->getResourceFactory()->marshalMetadataLinks($metadata, $links);
     }
 
     /**

--- a/src/RendererOptions.php
+++ b/src/RendererOptions.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Hal;
+
+use Zend\Stdlib\AbstractOptions;
+
+class RendererOptions extends AbstractOptions
+{
+    /**
+     * @var string
+     */
+    protected $defaultHydrator;
+
+    /**
+     * @var bool
+     */
+    protected $renderEmbeddedEntities = true;
+
+    /**
+     * @var bool
+     */
+    protected $renderEmbeddedCollections = true;
+
+    /**
+     * @var array
+     */
+    protected $hydrators = array();
+
+    /**
+     * @param string $hydrator
+     */
+    public function setDefaultHydrator($hydrator)
+    {
+        $this->defaultHydrator = $hydrator;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDefaultHydrator()
+    {
+        return $this->defaultHydrator;
+    }
+
+    /**
+     * @param bool $flag
+     */
+    public function setRenderEmbeddedEntities($flag)
+    {
+        $this->renderEmbeddedEntities = (bool) $flag;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRenderEmbeddedEntities()
+    {
+        return $this->renderEmbeddedEntities;
+    }
+
+    /**
+     * @param bool $flag
+     */
+    public function setRenderEmbeddedCollections($flag)
+    {
+        $this->renderEmbeddedCollections = (bool) $flag;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRenderEmbeddedCollections()
+    {
+        return $this->renderEmbeddedCollections;
+    }
+
+    /**
+     * @param array $hydrators
+     */
+    public function setHydrators(array $hydrators)
+    {
+        $this->hydrators = $hydrators;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHydrators()
+    {
+        return $this->hydrators;
+    }
+}

--- a/src/RendererOptions.php
+++ b/src/RendererOptions.php
@@ -28,7 +28,7 @@ class RendererOptions extends AbstractOptions
     /**
      * @var array
      */
-    protected $hydrators = array();
+    protected $hydrators = [];
 
     /**
      * @param string $hydrator

--- a/src/ResourceFactory.php
+++ b/src/ResourceFactory.php
@@ -7,15 +7,13 @@
 namespace ZF\Hal;
 
 use Closure;
-use JsonSerializable;
-use SplObjectStorage;
 use ZF\Hal\Collection;
 use ZF\Hal\Entity;
+use ZF\Hal\Extractor\EntityExtractor;
 use ZF\Hal\Exception;
 use ZF\Hal\Link\Link;
 use ZF\Hal\Link\LinkCollection;
 use ZF\Hal\Metadata\Metadata;
-use ZF\Hal\Metadata\MetadataMap;
 
 class ResourceFactory
 {
@@ -25,26 +23,18 @@ class ResourceFactory
     protected $entityHydratorManager;
 
     /**
-     * @var MetadataMap
+     * @var EntityExtractor
      */
-    protected $metadataMap;
-
-    /**
-     * Map of entities to their ZF\Hal\Entity serializations
-     *
-     * @var SplObjectStorage
-     */
-    protected $serializedEntities;
+    protected $entityExtractor;
 
     /**
      * @param EntityHydratorManager $entityHydratorManager
-     * @param  MetadataMap $map
+     * @param EntityExtractor $entityExtractor
      */
-    public function __construct(EntityHydratorManager $entityHydratorManager, MetadataMap $map)
+    public function __construct(EntityHydratorManager $entityHydratorManager, EntityExtractor $entityExtractor)
     {
         $this->entityHydratorManager = $entityHydratorManager;
-        $this->metadataMap           = $map;
-        $this->serializedEntities    = new SplObjectStorage();
+        $this->entityExtractor       = $entityExtractor;
     }
 
     /**
@@ -62,7 +52,7 @@ class ResourceFactory
             return $this->createCollectionFromMetadata($object, $metadata);
         }
 
-        $data = $this->convertEntityToArray($object);
+        $data = $this->entityExtractor->extract($object);
 
         $entityIdentifierName = $metadata->getEntityIdentifierName();
         if ($entityIdentifierName && ! isset($data[$entityIdentifierName])) {
@@ -121,38 +111,6 @@ class ResourceFactory
         }
 
         return $halCollection;
-    }
-
-    /**
-     * Convert an individual entity to an array
-     *
-     * @param  object $entity
-     * @return array
-     */
-    public function convertEntityToArray($entity)
-    {
-        if (isset($this->serializedEntities[$entity])) {
-            return $this->serializedEntities[$entity];
-        }
-
-        $array    = false;
-        $hydrator = $this->entityHydratorManager->getHydratorForEntity($entity);
-
-        if ($hydrator) {
-            $array = $hydrator->extract($entity);
-        }
-
-        if (false === $array && $entity instanceof JsonSerializable) {
-            $array = $entity->jsonSerialize();
-        }
-
-        if (false === $array) {
-            $array = get_object_vars($entity);
-        }
-
-        $this->serializedEntities[$entity] = $array;
-
-        return $array;
     }
 
     /**

--- a/src/ResourceFactory.php
+++ b/src/ResourceFactory.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Hal;
+
+use Closure;
+use JsonSerializable;
+use SplObjectStorage;
+use ZF\Hal\Collection;
+use ZF\Hal\Entity;
+use ZF\Hal\Exception;
+use ZF\Hal\Link\Link;
+use ZF\Hal\Link\LinkCollection;
+use ZF\Hal\Metadata\Metadata;
+use ZF\Hal\Metadata\MetadataMap;
+
+class ResourceFactory
+{
+    /**
+     * @var EntityHydratorManager
+     */
+    protected $entityHydratorManager;
+
+    /**
+     * @var MetadataMap
+     */
+    protected $metadataMap;
+
+    /**
+     * Map of entities to their ZF\Hal\Entity serializations
+     *
+     * @var SplObjectStorage
+     */
+    protected $serializedEntities;
+
+    /**
+     * @param EntityHydratorManager $entityHydratorManager
+     * @param  MetadataMap $map
+     */
+    public function __construct(EntityHydratorManager $entityHydratorManager, MetadataMap $map)
+    {
+        $this->entityHydratorManager = $entityHydratorManager;
+        $this->metadataMap           = $map;
+        $this->serializedEntities    = new SplObjectStorage();
+    }
+
+    /**
+     * Create a entity and/or collection based on a metadata map
+     *
+     * @param  object $object
+     * @param  Metadata $metadata
+     * @param  bool $renderEmbeddedEntities
+     * @return Entity|Collection
+     * @throws Exception\RuntimeException
+     */
+    public function createEntityFromMetadata($object, Metadata $metadata, $renderEmbeddedEntities = true)
+    {
+        if ($metadata->isCollection()) {
+            return $this->createCollectionFromMetadata($object, $metadata);
+        }
+
+        $data = $this->convertEntityToArray($object);
+
+        $entityIdentifierName = $metadata->getEntityIdentifierName();
+        if ($entityIdentifierName && ! isset($data[$entityIdentifierName])) {
+            throw new Exception\RuntimeException(sprintf(
+                'Unable to determine entity identifier for object of type "%s"; no fields matching "%s"',
+                get_class($object),
+                $entityIdentifierName
+            ));
+        }
+
+        $id = ($entityIdentifierName) ? $data[$entityIdentifierName]: null;
+
+        if (!$renderEmbeddedEntities) {
+            $object = array();
+        }
+
+        $halEntity = new Entity($object, $id);
+
+        $links = $halEntity->getLinks();
+        $this->marshalMetadataLinks($metadata, $links);
+
+        $forceSelfLink = $metadata->getForceSelfLink();
+        if ($forceSelfLink && !$links->has('self')) {
+            $link = $this->marshalLinkFromMetadata(
+                $metadata, $object, $id, $metadata->getRouteIdentifierName()
+            );
+            $links->add($link);
+        }
+
+        return $halEntity;
+    }
+
+    /**
+     * @param  object $object
+     * @param  Metadata $metadata
+     * @return Collection
+     */
+    public function createCollectionFromMetadata($object, Metadata $metadata)
+    {
+        $halCollection = new Collection($object);
+        $halCollection->setCollectionName($metadata->getCollectionName());
+        $halCollection->setCollectionRoute($metadata->getRoute());
+        $halCollection->setEntityRoute($metadata->getEntityRoute());
+        $halCollection->setRouteIdentifierName($metadata->getRouteIdentifierName());
+        $halCollection->setEntityIdentifierName($metadata->getEntityIdentifierName());
+
+        $links = $halCollection->getLinks();
+        $this->marshalMetadataLinks($metadata, $links);
+
+        $forceSelfLink = $metadata->getForceSelfLink();
+        if ($forceSelfLink && !$links->has('self')
+            && ($metadata->hasUrl() || $metadata->hasRoute())
+        ) {
+            $link = $this->marshalLinkFromMetadata($metadata, $object);
+            $links->add($link);
+        }
+
+        return $halCollection;
+    }
+
+    /**
+     * Convert an individual entity to an array
+     *
+     * @param  object $entity
+     * @return array
+     */
+    public function convertEntityToArray($entity)
+    {
+        if (isset($this->serializedEntities[$entity])) {
+            return $this->serializedEntities[$entity];
+        }
+
+        $array    = false;
+        $hydrator = $this->entityHydratorManager->getHydratorForEntity($entity);
+
+        if ($hydrator) {
+            $array = $hydrator->extract($entity);
+        }
+
+        if (false === $array && $entity instanceof JsonSerializable) {
+            $array = $entity->jsonSerialize();
+        }
+
+        if (false === $array) {
+            $array = get_object_vars($entity);
+        }
+
+        $this->serializedEntities[$entity] = $array;
+
+        return $array;
+    }
+
+    /**
+     * Creates a link object, given metadata and a resource
+     *
+     * @param  Metadata $metadata
+     * @param  object $object
+     * @param  null|string $id
+     * @param  null|string $routeIdentifierName
+     * @param  string $relation
+     * @return Link
+     * @throws Exception\RuntimeException
+     */
+    public function marshalLinkFromMetadata(
+        Metadata $metadata,
+        $object,
+        $id = null,
+        $routeIdentifierName = null,
+        $relation = 'self'
+    ) {
+        $link = new Link($relation);
+        if ($metadata->hasUrl()) {
+            $link->setUrl($metadata->getUrl());
+            return $link;
+        }
+
+        if (!$metadata->hasRoute()) {
+            throw new Exception\RuntimeException(sprintf(
+                'Unable to create a self link for resource of type "%s"; metadata does not contain a route or a url',
+                get_class($object)
+            ));
+        }
+
+        $params = $metadata->getRouteParams();
+
+        // process any callbacks
+        foreach ($params as $key => $param) {
+            // bind to the object if supported
+            if ($param instanceof Closure
+                && version_compare(PHP_VERSION, '5.4.0') >= 0
+            ) {
+                $param = $param->bindTo($object);
+            }
+
+            // pass the object for callbacks and non-bound closures
+            if (is_callable($param)) {
+                $params[$key] = call_user_func_array($param, array($object));
+            }
+        }
+
+        if ($routeIdentifierName) {
+            $params = array_merge($params, array($routeIdentifierName => $id));
+        }
+
+        $link->setRoute($metadata->getRoute(), $params, $metadata->getRouteOptions());
+        return $link;
+    }
+
+    /**
+     * Inject any links found in the metadata into the resource's link collection
+     *
+     * @param  Metadata $metadata
+     * @param  LinkCollection $links
+     */
+    public function marshalMetadataLinks(Metadata $metadata, LinkCollection $links)
+    {
+        foreach ($metadata->getLinks() as $linkData) {
+            $link = Link::factory($linkData);
+            $links->add($link);
+        }
+    }
+}

--- a/src/ResourceFactory.php
+++ b/src/ResourceFactory.php
@@ -77,7 +77,10 @@ class ResourceFactory
         $forceSelfLink = $metadata->getForceSelfLink();
         if ($forceSelfLink && !$links->has('self')) {
             $link = $this->marshalLinkFromMetadata(
-                $metadata, $object, $id, $metadata->getRouteIdentifierName()
+                $metadata,
+                $object,
+                $id,
+                $metadata->getRouteIdentifierName()
             );
             $links->add($link);
         }

--- a/src/ResourceFactory.php
+++ b/src/ResourceFactory.php
@@ -66,7 +66,7 @@ class ResourceFactory
         $id = ($entityIdentifierName) ? $data[$entityIdentifierName]: null;
 
         if (!$renderEmbeddedEntities) {
-            $object = array();
+            $object = [];
         }
 
         $halEntity = new Entity($object, $id);
@@ -160,12 +160,12 @@ class ResourceFactory
 
             // pass the object for callbacks and non-bound closures
             if (is_callable($param)) {
-                $params[$key] = call_user_func_array($param, array($object));
+                $params[$key] = call_user_func_array($param, [$object]);
             }
         }
 
         if ($routeIdentifierName) {
-            $params = array_merge($params, array($routeIdentifierName => $id));
+            $params = array_merge($params, [$routeIdentifierName => $id]);
         }
 
         $link->setRoute($metadata->getRoute(), $params, $metadata->getRouteOptions());

--- a/test/EntityHydratorManagerTest.php
+++ b/test/EntityHydratorManagerTest.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Hal\Extractor;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Stdlib\Hydrator\HydratorPluginManager;
+use ZF\Hal\EntityHydratorManager;
+use ZF\Hal\Metadata\MetadataMap;
+use ZFTest\Hal\Plugin\TestAsset;
+use ZFTest\Hal\Plugin\TestAsset\DummyHydrator;
+
+/**
+ * @subpackage UnitTest
+ */
+class EntityHydratorManagerTest extends TestCase
+{
+    public function testAddHydratorGivenEntityClassAndHydratorInstanceShouldAssociateThem()
+    {
+        $entity        = new TestAsset\Entity('foo', 'Foo Bar');
+        $hydratorClass = 'ZFTest\Hal\Plugin\TestAsset\DummyHydrator';
+        $hydrator      = new $hydratorClass();
+
+        $metadataMap = new MetadataMap();
+        $hydratorPluginManager = new HydratorPluginManager();
+        $entityHydratorManager = new EntityHydratorManager($hydratorPluginManager, $metadataMap);
+
+        $entityHydratorManager->addHydrator(
+            'ZFTest\Hal\Plugin\TestAsset\Entity',
+            $hydrator
+        );
+
+        $entityHydrator = $entityHydratorManager->getHydratorForEntity($entity);
+        $this->assertInstanceOf($hydratorClass, $entityHydrator);
+        $this->assertSame($hydrator, $entityHydrator);
+    }
+
+    public function testAddHydratorGivenEntityAndHydratorClassesShouldAssociateThem()
+    {
+        $entity        = new TestAsset\Entity('foo', 'Foo Bar');
+        $hydratorClass = 'ZFTest\Hal\Plugin\TestAsset\DummyHydrator';
+
+        $metadataMap = new MetadataMap();
+        $hydratorPluginManager = new HydratorPluginManager();
+        $entityHydratorManager = new EntityHydratorManager($hydratorPluginManager, $metadataMap);
+
+        $entityHydratorManager->addHydrator(
+            'ZFTest\Hal\Plugin\TestAsset\Entity',
+            $hydratorClass
+        );
+
+        $this->assertInstanceOf(
+            $hydratorClass,
+            $entityHydratorManager->getHydratorForEntity($entity)
+        );
+    }
+
+    public function testAddHydratorDoesntFailWithAutoInvokables()
+    {
+        $metadataMap           = new MetadataMap();
+        $hydratorPluginManager = new HydratorPluginManager();
+        $entityHydratorManager = new EntityHydratorManager($hydratorPluginManager, $metadataMap);
+
+        $entityHydratorManager->addHydrator('stdClass', 'ZFTest\Hal\Plugin\TestAsset\DummyHydrator');
+
+        $this->assertInstanceOf(
+            'ZFTest\Hal\Plugin\TestAsset\DummyHydrator',
+            $entityHydratorManager->getHydratorForEntity(new \stdClass)
+        );
+    }
+
+    public function testGetHydratorForEntityGivenEntityDefinedInMetadataMapShouldReturnDefaultHydrator()
+    {
+        $entity        = new TestAsset\Entity('foo', 'Foo Bar');
+        $hydratorClass = 'ZFTest\Hal\Plugin\TestAsset\DummyHydrator';
+
+        $metadataMap = new MetadataMap(array(
+            'ZFTest\Hal\Plugin\TestAsset\Entity' => array(
+                'hydrator' => $hydratorClass,
+            ),
+        ));
+
+        $hydratorPluginManager = new HydratorPluginManager();
+        $entityHydratorManager = new EntityHydratorManager($hydratorPluginManager, $metadataMap);
+
+        $this->assertInstanceOf(
+            $hydratorClass,
+            $entityHydratorManager->getHydratorForEntity($entity)
+        );
+    }
+
+    public function testGetHydratorForEntityGivenUnkownEntityShouldReturnDefaultHydrator()
+    {
+        $entity = new TestAsset\Entity('foo', 'Foo Bar');
+        $defaultHydrator = new DummyHydrator();
+
+        $metadataMap           = new MetadataMap();
+        $hydratorPluginManager = new HydratorPluginManager();
+        $entityHydratorManager = new EntityHydratorManager($hydratorPluginManager, $metadataMap);
+
+        $entityHydratorManager->setDefaultHydrator($defaultHydrator);
+
+        $entityHydrator = $entityHydratorManager->getHydratorForEntity($entity);
+
+        $this->assertSame($defaultHydrator, $entityHydrator);
+    }
+
+    public function testGetHydratorForEntityGivenUnkownEntityAndNoDefaultHydratorDefinedShouldReturnFalse()
+    {
+        $entity = new TestAsset\Entity('foo', 'Foo Bar');
+
+        $metadataMap           = new MetadataMap();
+        $hydratorPluginManager = new HydratorPluginManager();
+        $entityHydratorManager = new EntityHydratorManager($hydratorPluginManager, $metadataMap);
+
+        $hydrator = $entityHydratorManager->getHydratorForEntity($entity);
+
+        $this->assertFalse($hydrator);
+    }
+}

--- a/test/EntityHydratorManagerTest.php
+++ b/test/EntityHydratorManagerTest.php
@@ -77,11 +77,11 @@ class EntityHydratorManagerTest extends TestCase
         $entity        = new TestAsset\Entity('foo', 'Foo Bar');
         $hydratorClass = 'ZFTest\Hal\Plugin\TestAsset\DummyHydrator';
 
-        $metadataMap = new MetadataMap(array(
-            'ZFTest\Hal\Plugin\TestAsset\Entity' => array(
+        $metadataMap = new MetadataMap([
+            'ZFTest\Hal\Plugin\TestAsset\Entity' => [
                 'hydrator' => $hydratorClass,
-            ),
-        ));
+            ],
+        ]);
 
         $hydratorPluginManager = new HydratorPluginManager();
         $entityHydratorManager = new EntityHydratorManager($hydratorPluginManager, $metadataMap);

--- a/test/Extractor/EntityExtractorTest.php
+++ b/test/Extractor/EntityExtractorTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Hal\Extractor;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Stdlib\Hydrator\ObjectProperty;
+use ZF\Hal\Extractor\EntityExtractor;
+use ZFTest\Hal\Plugin\TestAsset;
+
+/**
+ * @subpackage UnitTest
+ */
+class EntityExtractorTest extends TestCase
+{
+    public function testExtractGivenEntityWithAssociateHydratorShouldExtractData()
+    {
+        $hydrator = new ObjectProperty();
+
+        $entity = new TestAsset\Entity('foo', 'Foo Bar');
+        $entityHydratorManager = $this->getMockBuilder('ZF\Hal\EntityHydratorManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $entityHydratorManager
+            ->method('getHydratorForEntity')
+            ->with($entity)
+            ->will($this->returnValue($hydrator));
+
+        $extractor = new EntityExtractor($entityHydratorManager);
+
+        $this->assertSame($extractor->extract($entity), $hydrator->extract($entity));
+    }
+
+    public function testExtractGivenEntityWithoutAssociateHydratorShouldExtractPublicProperties()
+    {
+        $entity = new TestAsset\Entity('foo', 'Foo Bar');
+        $entityHydratorManager = $this->getMockBuilder('ZF\Hal\EntityHydratorManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $entityHydratorManager
+            ->method('getHydratorForEntity')
+            ->with($entity)
+            ->will($this->returnValue(null));
+
+        $extractor = new EntityExtractor($entityHydratorManager);
+        $data = $extractor->extract($entity);
+
+        $this->assertArrayHasKey('id', $data);
+        $this->assertArrayHasKey('name', $data);
+        $this->assertArrayNotHasKey('doNotExportMe', $data);
+    }
+
+    public function testExtractTwiceGivenSameEntityShouldProcessExtractionOnceAndReturnSameData()
+    {
+        $entity = new TestAsset\Entity('foo', 'Foo Bar');
+        $entityHydratorManager = $this->getMockBuilder('ZF\Hal\EntityHydratorManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $entityHydratorManager
+            ->expects($this->once())
+            ->method('getHydratorForEntity')
+            ->with($entity)
+            ->will($this->returnValue(null));
+
+        $extractor = new EntityExtractor($entityHydratorManager);
+
+        $data1 = $extractor->extract($entity);
+        $data2 = $extractor->extract($entity);
+
+        $this->assertSame($data1, $data2);
+    }
+}

--- a/test/Factory/HalViewHelperFactoryTest.php
+++ b/test/Factory/HalViewHelperFactoryTest.php
@@ -13,7 +13,7 @@ use Zend\Stdlib\Hydrator\HydratorPluginManager;
 use Zend\View\Helper\ServerUrl;
 use Zend\View\Helper\Url;
 use ZF\Hal\Factory\HalViewHelperFactory;
-use ZF\Hal\Plugin;
+use ZF\Hal\RendererOptions;
 
 class HalViewHelperFactoryTest extends TestCase
 {
@@ -21,7 +21,14 @@ class HalViewHelperFactoryTest extends TestCase
     {
         $services = new ServiceManager();
 
-        $services->setService('Config', $config);
+        $services->setService('ZF\Hal\HalConfig', $config);
+
+        if (isset($config['renderer']) && is_array($config['renderer'])) {
+            $rendererOptions = new RendererOptions($config['renderer']);
+        } else {
+            $rendererOptions = new RendererOptions();
+        }
+        $services->setService('ZF\Hal\RendererOptions', $rendererOptions);
 
         $metadataMap = $this->getMock('ZF\Hal\Metadata\MetadataMap');
         $metadataMap
@@ -46,7 +53,6 @@ class HalViewHelperFactoryTest extends TestCase
             ->will($this->returnValue(new Url()));
 
         $this->pluginManager
-            ->expects($this->any())
             ->method('getServiceLocator')
             ->will($this->returnValue($services));
     }
@@ -61,73 +67,14 @@ class HalViewHelperFactoryTest extends TestCase
         $this->assertInstanceOf('ZF\Hal\Plugin\Hal', $plugin);
     }
 
-    public function testHalViewHelperFactoryInjectsDefaultHydratorIfPresentInConfig()
-    {
-        $config = [
-            'zf-hal' => [
-                'renderer' => [
-                    'default_hydrator' => 'ObjectProperty',
-                ],
-            ],
-        ];
-
-        $this->setupPluginManager($config);
-
-        $factory = new HalViewHelperFactory();
-        $plugin = $factory->createService($this->pluginManager);
-
-        $this->assertInstanceOf('ZF\Hal\Plugin\Hal', $plugin);
-        $this->assertAttributeInstanceOf('Zend\Stdlib\Hydrator\ObjectProperty', 'defaultHydrator', $plugin);
-    }
-
-    public function testHalViewHelperFactoryInjectsHydratorMappingsIfPresentInConfig()
-    {
-        $config = [
-            'zf-hal' => [
-                'renderer' => [
-                    'hydrators' => [
-                        'Some\MadeUp\Component'            => 'ClassMethods',
-                        'Another\MadeUp\Component'         => 'Reflection',
-                        'StillAnother\MadeUp\Component'    => 'ArraySerializable',
-                        'A\Component\With\SharedHydrators' => 'Reflection',
-                    ],
-                ],
-            ],
-        ];
-
-        $this->setupPluginManager($config);
-
-        $factory = new HalViewHelperFactory();
-        $plugin = $factory->createService($this->pluginManager);
-
-        $r             = new ReflectionObject($plugin);
-        $hydratorsProp = $r->getProperty('hydratorMap');
-        $hydratorsProp->setAccessible(true);
-        $hydratorMap = $hydratorsProp->getValue($plugin);
-
-        $hydrators = $plugin->getHydratorManager();
-
-        $this->assertInternalType('array', $hydratorMap);
-
-        foreach ($config['zf-hal']['renderer']['hydrators'] as $class => $serviceName) {
-            $key = strtolower($class);
-            $this->assertArrayHasKey($key, $hydratorMap);
-
-            $hydrator = $hydratorMap[$key];
-            $this->assertSame(get_class($hydrators->get($serviceName)), get_class($hydrator));
-        }
-    }
-
     /**
      * @group fail
      */
     public function testOptionUseProxyIfPresentInConfig()
     {
         $options = [
-            'zf-hal' => [
-                'options' => [
-                    'use_proxy' => true,
-                ],
+            'options' => [
+                'use_proxy' => true,
             ],
         ];
 

--- a/test/Factory/MetadataMapFactoryTest.php
+++ b/test/Factory/MetadataMapFactoryTest.php
@@ -17,9 +17,9 @@ class MetadataMapFactoryTest extends TestCase
 
         $services
             ->expects($this->at(0))
-            ->method('has')
-            ->with('config')
-            ->will($this->returnValue(false));
+            ->method('get')
+            ->with('ZF\Hal\HalConfig')
+            ->will($this->returnValue([]));
 
         $services
             ->expects($this->at(1))
@@ -37,47 +37,37 @@ class MetadataMapFactoryTest extends TestCase
     {
         $services = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
 
-        $services
-            ->expects($this->at(0))
-            ->method('has')
-            ->with('config')
-            ->will($this->returnValue(true));
-
         $config = [
-            'zf-hal' => [
-                'metadata_map' => [
-                    'ZFTest\Hal\Plugin\TestAsset\Entity' => [
-                        'hydrator'   => 'Zend\Stdlib\Hydrator\ObjectProperty',
-                        'route_name' => 'hostname/resource',
-                        'route_identifier_name' => 'id',
-                        'entity_identifier_name' => 'id',
-                    ],
-                    'ZFTest\Hal\Plugin\TestAsset\EmbeddedEntity' => [
-                        'hydrator' => 'Zend\Stdlib\Hydrator\ObjectProperty',
-                        'route'    => 'hostname/embedded',
-                        'route_identifier_name' => 'id',
-                        'entity_identifier_name' => 'id',
-                        'force_self_link' => true, // same as previous
-                    ],
-                    'ZFTest\Hal\Plugin\TestAsset\EmbeddedEntityWithCustomIdentifier' => [
-                        'hydrator'        => 'Zend\Stdlib\Hydrator\ObjectProperty',
-                        'route'           => 'hostname/embedded_custom',
-                        'route_identifier_name' => 'custom_id',
-                        'entity_identifier_name' => 'custom_id',
-                        'force_self_link' => false,
-                    ],
+            'metadata_map' => [
+                'ZFTest\Hal\Plugin\TestAsset\Entity' => [
+                    'hydrator'   => 'Zend\Stdlib\Hydrator\ObjectProperty',
+                    'route_name' => 'hostname/resource',
+                    'route_identifier_name' => 'id',
+                    'entity_identifier_name' => 'id',
+                ],
+                'ZFTest\Hal\Plugin\TestAsset\EmbeddedEntity' => [
+                    'hydrator' => 'Zend\Stdlib\Hydrator\ObjectProperty',
+                    'route'    => 'hostname/embedded',
+                    'route_identifier_name' => 'id',
+                    'entity_identifier_name' => 'id',
+                ],
+                'ZFTest\Hal\Plugin\TestAsset\EmbeddedEntityWithCustomIdentifier' => [
+                    'hydrator'        => 'Zend\Stdlib\Hydrator\ObjectProperty',
+                    'route'           => 'hostname/embedded_custom',
+                    'route_identifier_name' => 'custom_id',
+                    'entity_identifier_name' => 'custom_id',
                 ],
             ],
         ];
 
         $services
-            ->expects($this->at(1))
+            ->expects($this->at(0))
             ->method('get')
-            ->with('config')
+            ->with('ZF\Hal\HalConfig')
             ->will($this->returnValue($config));
 
         $services
-            ->expects($this->at(2))
+            ->expects($this->at(1))
             ->method('has')
             ->with('HydratorManager')
             ->will($this->returnValue(false));
@@ -87,7 +77,7 @@ class MetadataMapFactoryTest extends TestCase
 
         $this->assertInstanceOf('ZF\Hal\Metadata\MetadataMap', $metadataMap);
 
-        foreach ($config['zf-hal']['metadata_map'] as $key => $value) {
+        foreach ($config['metadata_map'] as $key => $value) {
             $this->assertTrue($metadataMap->has($key));
             $this->assertInstanceOf('ZF\Hal\Metadata\Metadata', $metadataMap->get($key));
         }

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -19,6 +19,7 @@ use Zend\View\Helper\Url as UrlHelper;
 use Zend\View\Helper\ServerUrl as ServerUrlHelper;
 use ZF\Hal\Collection;
 use ZF\Hal\Entity;
+use ZF\Hal\EntityHydratorManager;
 use ZF\Hal\Extractor\LinkCollectionExtractor;
 use ZF\Hal\Extractor\LinkExtractor;
 use ZF\Hal\Link\Link;
@@ -1197,17 +1198,6 @@ class HalTest extends TestCase
         $serialized2 = $this->plugin->renderEntity($entity2);
 
         $this->assertSame($serialized1, $serialized2);
-
-        $data = $serialized1;
-        unset($data['_links']);
-
-        $r = new ReflectionObject($this->plugin);
-        $p = $r->getProperty('serializedEntities');
-        $p->setAccessible(true);
-        $serializedEntities = $p->getValue($this->plugin);
-        $this->assertInstanceOf('SplObjectStorage', $serializedEntities);
-        $this->assertTrue($serializedEntities->contains($foo));
-        $this->assertSame($data, $serializedEntities[$foo]);
     }
 
     /**
@@ -1714,9 +1704,9 @@ class HalTest extends TestCase
         $object = new TestAsset\Entity('foo', 'Foo');
         $metadata = new MetadataMap([
             'ZFTest\Hal\Plugin\TestAsset\Entity' => [
-                'hydrator'         => 'Zend\Stdlib\Hydrator\ObjectProperty',
-                'route_name'       => 'hostname/resource',
-                'links'            => [],
+                'hydrator'        => 'Zend\Stdlib\Hydrator\ObjectProperty',
+                'route_name'      => 'hostname/resource',
+                'links'           => [],
                 'force_self_link' => false,
             ],
         ]);
@@ -1750,21 +1740,19 @@ class HalTest extends TestCase
 
     public function testCreateCollectionFromMetadataWithoutForcedSelfLinks()
     {
-        $set = new TestAsset\Collection(
-            [
-                (object) ['id' => 'foo', 'name' => 'foo'],
-                (object) ['id' => 'bar', 'name' => 'bar'],
-                (object) ['id' => 'baz', 'name' => 'baz'],
-            ]
-        );
+        $set = new TestAsset\Collection([
+            (object) ['id' => 'foo', 'name' => 'foo'],
+            (object) ['id' => 'bar', 'name' => 'bar'],
+            (object) ['id' => 'baz', 'name' => 'baz'],
+        ]);
 
         $metadata = new MetadataMap([
             'ZFTest\Hal\Plugin\TestAsset\Collection' => [
-                'is_collection'       => true,
-                'route_name'          => 'hostname/contacts',
-                'entity_route_name'   => 'hostname/embedded',
-                'links'               => [],
-                'force_self_link'     => false,
+                'is_collection'     => true,
+                'route_name'        => 'hostname/contacts',
+                'entity_route_name' => 'hostname/embedded',
+                'links'             => [],
+                'force_self_link'   => false,
             ],
         ]);
 
@@ -1783,11 +1771,11 @@ class HalTest extends TestCase
         $collection = ['foo' => 'bar'];
         $metadata = new MetadataMap([
             'ZF\Hal\Collection' => [
-                'is_collection'       => true,
-                'route_name'          => 'hostname/contacts',
-                'entity_route_name'   => 'hostname/embedded',
-                'links'               => [],
-                'force_self_link'     => false,
+                'is_collection'     => true,
+                'route_name'        => 'hostname/contacts',
+                'entity_route_name' => 'hostname/embedded',
+                'links'             => [],
+                'force_self_link'   => false,
             ],
         ]);
         $this->plugin->setMetadataMap($metadata);

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -319,7 +319,9 @@ class HalTest extends TestCase
     {
         $object   = new TestAsset\JsonSerializableEntity('foo', 'Foo');
         $entity   = new Entity($object, 'foo');
+
         $rendered = $this->plugin->renderEntity($entity);
+
         $this->assertArrayHasKey('id', $rendered);
         $this->assertArrayNotHasKey('name', $rendered);
         $this->assertArrayHasKey('_links', $rendered);
@@ -697,52 +699,6 @@ class HalTest extends TestCase
     }
 
     /**
-     * @group 79
-     */
-    public function testInjectsLinksFromMetadataWhenCreatingEntity()
-    {
-        $object = new TestAsset\Entity('foo', 'Foo');
-        $entity = new Entity($object, 'foo');
-
-        $metadata = new MetadataMap([
-            'ZFTest\Hal\Plugin\TestAsset\Entity' => [
-                'hydrator'   => 'Zend\Stdlib\Hydrator\ObjectProperty',
-                'route_name' => 'hostname/resource',
-                'links'      => [
-                    [
-                        'rel' => 'describedby',
-                        'url' => 'http://example.com/api/help/resource',
-                    ],
-                    [
-                        'rel' => 'children',
-                        'route' => [
-                            'name' => 'resource/children',
-                        ],
-                    ],
-                ],
-            ],
-        ]);
-
-        $this->plugin->setMetadataMap($metadata);
-        $entity = $this->plugin->createEntityFromMetadata(
-            $object,
-            $metadata->get('ZFTest\Hal\Plugin\TestAsset\Entity')
-        );
-        $this->assertInstanceof('ZF\Hal\Entity', $entity);
-        $links = $entity->getLinks();
-        $this->assertTrue($links->has('describedby'));
-        $this->assertTrue($links->has('children'));
-
-        $describedby = $links->get('describedby');
-        $this->assertTrue($describedby->hasUrl());
-        $this->assertEquals('http://example.com/api/help/resource', $describedby->getUrl());
-
-        $children = $links->get('children');
-        $this->assertTrue($children->hasRoute());
-        $this->assertEquals('resource/children', $children->getRoute());
-    }
-
-    /**
      * @group 47
      */
     public function testRetainsLinksInjectedViaMetadataDuringCreateEntity()
@@ -783,107 +739,6 @@ class HalTest extends TestCase
         $children = $links->get('children');
         $this->assertTrue($children->hasRoute());
         $this->assertEquals('resource/children', $children->getRoute());
-    }
-
-    /**
-     * @group 79
-     */
-    public function testInjectsLinksFromMetadataWhenCreatingCollection()
-    {
-        $set = new TestAsset\Collection(
-            [
-                (object) ['id' => 'foo', 'name' => 'foo'],
-                (object) ['id' => 'bar', 'name' => 'bar'],
-                (object) ['id' => 'baz', 'name' => 'baz'],
-            ]
-        );
-
-        $metadata = new MetadataMap([
-            'ZFTest\Hal\Plugin\TestAsset\Collection' => [
-                'is_collection'       => true,
-                'route_name'          => 'hostname/contacts',
-                'entity_route_name'   => 'hostname/embedded',
-                'links'               => [
-                    [
-                        'rel' => 'describedby',
-                        'url' => 'http://example.com/api/help/collection',
-                    ],
-                ],
-            ],
-        ]);
-
-        $this->plugin->setMetadataMap($metadata);
-
-        $collection = $this->plugin->createCollectionFromMetadata(
-            $set,
-            $metadata->get('ZFTest\Hal\Plugin\TestAsset\Collection')
-        );
-        $this->assertInstanceof('ZF\Hal\Collection', $collection);
-        $links = $collection->getLinks();
-        $this->assertTrue($links->has('describedby'));
-        $link = $links->get('describedby');
-        $this->assertTrue($link->hasUrl());
-        $this->assertEquals('http://example.com/api/help/collection', $link->getUrl());
-    }
-
-    /**
-     * Test that the hal metadata route params config allows callables.
-     *
-     * All callables should be passed the object being used for entity creation.
-     * If closure binding is supported, any closures should be bound to that
-     * object.
-     *
-     * The return value should be used as the route param for the link (in
-     * place of the callable).
-     */
-    public function testRouteParamsAllowsCallable()
-    {
-        $object = new TestAsset\Entity('foo', 'Foo');
-
-        $callback = $this->getMock('stdClass', ['callback']);
-        $callback->expects($this->atLeastOnce())
-                 ->method('callback')
-                 ->with($this->equalTo($object))
-                 ->will($this->returnValue('callback-param'));
-
-        $test = $this;
-
-        $metadata = new MetadataMap([
-            'ZFTest\Hal\Plugin\TestAsset\Entity' => [
-                'hydrator'     => 'Zend\Stdlib\Hydrator\ObjectProperty',
-                'route_name'   => 'hostname/resource',
-                'route_params' => [
-                    'test-1' => [$callback, 'callback'],
-                    'test-2' => function ($expected) use ($object, $test) {
-                        $test->assertSame($expected, $object);
-                        if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
-                            $test->assertSame($object, $this);
-                        }
-
-                        return 'closure-param';
-                    },
-                ],
-            ],
-        ]);
-
-        $this->plugin->setMetadataMap($metadata);
-        $entity = $this->plugin->createEntityFromMetadata(
-            $object,
-            $metadata->get('ZFTest\Hal\Plugin\TestAsset\Entity')
-        );
-        $this->assertInstanceof('ZF\Hal\Entity', $entity);
-
-        $links = $entity->getLinks();
-        $this->assertTrue($links->has('self'));
-
-        $self = $links->get('self');
-        $params = $self->getRouteParams();
-
-        $this->assertArrayHasKey('test-1', $params);
-        $this->assertEquals('callback-param', $params['test-1']);
-
-        $this->assertArrayHasKey('test-2', $params);
-        $this->assertEquals('closure-param', $params['test-2']);
     }
 
     /**
@@ -1165,54 +1020,6 @@ class HalTest extends TestCase
     }
 
     /**
-     * Test that the convertEntityToArray() caches serialization results by object.
-     *
-     * This is done because if you call createEntity() -- say, from a ZF\Rest\RestController,
-     * you may end up calling convertEntityToArray() twice -- once to create the HAL
-     * entity with the appropriate identifier, and another when creating the serialized
-     * representation.
-     *
-     * This method is testing internals of the plugin; realistically, the behavior is
-     * transparent to the end-user.
-     *
-     * @group 33
-     */
-    public function testConvertEntityToArrayCachesSerialization()
-    {
-        $metadata = new MetadataMap([
-            'ZFTest\Hal\Plugin\TestAsset\Entity' => [
-                'hydrator'   => 'Zend\Stdlib\Hydrator\ObjectProperty',
-                'route_name' => 'hostname/resource',
-                'route_identifier_name' => 'id',
-                'entity_identifier_name' => 'id',
-            ],
-        ]);
-        $this->plugin->setMetadataMap($metadata);
-
-        $foo = new TestAsset\Entity('foo', 'Foo Bar');
-
-        $entity1 = $this->plugin->createEntityFromMetadata($foo, $metadata->get($foo));
-        $serialized1 = $this->plugin->renderEntity($entity1);
-
-        $entity2 = $this->plugin->createEntityFromMetadata($foo, $metadata->get($foo));
-        $serialized2 = $this->plugin->renderEntity($entity2);
-
-        $this->assertSame($serialized1, $serialized2);
-    }
-
-    /**
-     * @group 91
-     */
-    public function testConvertEntityToArrayOnlyConvertsPublicProperties()
-    {
-        $foo = new TestAsset\Entity('foo', 'Foo Bar');
-        $entity = $this->plugin->createEntity($foo, 'resource', 'foo_id');
-        $data = $this->plugin->renderEntity($entity);
-
-        $this->assertFalse(array_key_exists('doNotExportMe', $data));
-    }
-
-    /**
      * @group 39
      */
     public function testCreateEntityPassesNullValueForIdentifierIfNotDiscovered()
@@ -1228,16 +1035,6 @@ class HalTest extends TestCase
         $link = $links->get('self');
         $params = $link->getRouteParams();
         $this->assertEquals([], $params);
-    }
-
-    public function testAddHydratorDoesntFailWithAutoInvokables()
-    {
-        $this->plugin->addHydrator('stdClass', 'ZFTest\Hal\Plugin\TestAsset\DummyHydrator');
-
-        $this->assertInstanceOf(
-            'ZFTest\Hal\Plugin\TestAsset\DummyHydrator',
-            $this->plugin->getHydratorForEntity(new \stdClass)
-        );
     }
 
     /**

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -442,33 +442,32 @@ class HalTest extends TestCase
         $entity->first_child  = new TestAsset\EmbeddedEntity('bar', 'Bar');
         $entity->second_child = new TestAsset\EmbeddedEntityWithCustomIdentifier('baz', 'Baz');
 
-        $metadata = new MetadataMap(array(
-            'ZFTest\Hal\Plugin\TestAsset\EmbeddedEntity' => array(
+        $metadata = new MetadataMap([
+            'ZFTest\Hal\Plugin\TestAsset\EmbeddedEntity' => [
                 'hydrator' => 'Zend\Stdlib\Hydrator\ObjectProperty',
                 'route'    => 'hostname/embedded',
-            ),
-            'ZFTest\Hal\Plugin\TestAsset\EmbeddedEntityWithCustomIdentifier' => array(
+            ],
+            'ZFTest\Hal\Plugin\TestAsset\EmbeddedEntityWithCustomIdentifier' => [
                 'hydrator'        => 'Zend\Stdlib\Hydrator\ObjectProperty',
                 'route'           => 'hostname/embedded_custom',
                 'route_identifier_name' => 'custom_id',
                 'entity_identifier_name' => 'custom_id',
-            ),
-
-            'ZFTest\Hal\Plugin\TestAsset\Collection' => array(
+            ],
+            'ZFTest\Hal\Plugin\TestAsset\Collection' => [
                 'is_collection'  => true,
                 'route'          => 'hostname/contacts',
                 'entity_route'   => 'hostname/embedded',
-            ),
-            'ZFTest\Hal\Plugin\TestAsset\Entity' => array(
+            ],
+            'ZFTest\Hal\Plugin\TestAsset\Entity' => [
                 'hydrator'   => 'Zend\Stdlib\Hydrator\ObjectProperty',
                 'route_name' => 'hostname/resource',
-            ),
-        ));
+            ],
+        ]);
 
         $this->plugin->setMetadataMap($metadata);
         $this->plugin->setRenderEmbeddedEntities(false);
 
-        $collection = new Collection(array($entity), 'hostname/resource');
+        $collection = new Collection([$entity], 'hostname/resource');
         $self = new Link('self');
         $self->setRoute('hostname/resource');
         $collection->getLinks()->add($self);
@@ -1062,12 +1061,12 @@ class HalTest extends TestCase
     {
         return [
             /**
-             * array(
+             * [
              *     $entity,
              *     $metadataMap,
              *     $expectedResult,
              *     $exception,
-             * )
+             * ]
              */
             [
                 $this->createNestedEntity(),

--- a/test/ResourceFactoryTest.php
+++ b/test/ResourceFactoryTest.php
@@ -26,24 +26,24 @@ class ResourceFactoryTest extends TestCase
     {
         $object = new TestAsset\Entity('foo', 'Foo');
 
-        $metadata = new MetadataMap(array(
-            'ZFTest\Hal\Plugin\TestAsset\Entity' => array(
+        $metadata = new MetadataMap([
+            'ZFTest\Hal\Plugin\TestAsset\Entity' => [
                 'hydrator'   => 'Zend\Stdlib\Hydrator\ObjectProperty',
                 'route_name' => 'hostname/resource',
-                'links'      => array(
-                    array(
+                'links'      => [
+                    [
                         'rel' => 'describedby',
                         'url' => 'http://example.com/api/help/resource',
-                    ),
-                    array(
+                    ],
+                    [
                         'rel' => 'children',
-                        'route' => array(
+                        'route' => [
                             'name' => 'resource/children',
-                        ),
-                    ),
-                ),
-            ),
-        ));
+                        ],
+                    ],
+                ],
+            ],
+        ]);
 
         $resourceFactory = $this->getResourceFactory($metadata);
 
@@ -80,7 +80,7 @@ class ResourceFactoryTest extends TestCase
     {
         $object = new TestAsset\Entity('foo', 'Foo');
 
-        $callback = $this->getMock('stdClass', array('callback'));
+        $callback = $this->getMock('stdClass', ['callback']);
         $callback->expects($this->atLeastOnce())
                  ->method('callback')
                  ->with($this->equalTo($object))
@@ -88,12 +88,12 @@ class ResourceFactoryTest extends TestCase
 
         $test = $this;
 
-        $metadata = new MetadataMap(array(
-            'ZFTest\Hal\Plugin\TestAsset\Entity' => array(
+        $metadata = new MetadataMap([
+            'ZFTest\Hal\Plugin\TestAsset\Entity' => [
                 'hydrator'     => 'Zend\Stdlib\Hydrator\ObjectProperty',
                 'route_name'   => 'hostname/resource',
-                'route_params' => array(
-                    'test-1' => array($callback, 'callback'),
+                'route_params' => [
+                    'test-1' => [$callback, 'callback'],
                     'test-2' => function ($expected) use ($object, $test) {
                         $test->assertSame($expected, $object);
                         if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
@@ -102,9 +102,9 @@ class ResourceFactoryTest extends TestCase
 
                         return 'closure-param';
                     },
-                ),
-            ),
-        ));
+                ],
+            ],
+        ]);
 
         $resourceFactory = $this->getResourceFactory($metadata);
 
@@ -133,25 +133,25 @@ class ResourceFactoryTest extends TestCase
      */
     public function testInjectsLinksFromMetadataWhenCreatingCollection()
     {
-        $set = new TestAsset\Collection(array(
-            (object) array('id' => 'foo', 'name' => 'foo'),
-            (object) array('id' => 'bar', 'name' => 'bar'),
-            (object) array('id' => 'baz', 'name' => 'baz'),
-        ));
+        $set = new TestAsset\Collection([
+            (object) ['id' => 'foo', 'name' => 'foo'],
+            (object) ['id' => 'bar', 'name' => 'bar'],
+            (object) ['id' => 'baz', 'name' => 'baz'],
+        ]);
 
-        $metadata = new MetadataMap(array(
-            'ZFTest\Hal\Plugin\TestAsset\Collection' => array(
+        $metadata = new MetadataMap([
+            'ZFTest\Hal\Plugin\TestAsset\Collection' => [
                 'is_collection'       => true,
                 'route_name'          => 'hostname/contacts',
                 'entity_route_name'   => 'hostname/embedded',
-                'links'               => array(
-                    array(
+                'links'               => [
+                    [
                         'rel' => 'describedby',
                         'url' => 'http://example.com/api/help/collection',
-                    ),
-                ),
-            ),
-        ));
+                    ],
+                ],
+            ],
+        ]);
 
         $resourceFactory = $this->getResourceFactory($metadata);
 

--- a/test/ResourceFactoryTest.php
+++ b/test/ResourceFactoryTest.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Hal;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Stdlib\Hydrator\HydratorPluginManager;
+use ZF\Hal\EntityHydratorManager;
+use ZF\Hal\Extractor\EntityExtractor;
+use ZF\Hal\Metadata\MetadataMap;
+use ZF\Hal\ResourceFactory;
+use ZFTest\Hal\Plugin\TestAsset;
+
+/**
+ * @subpackage UnitTest
+ */
+class ResourceFactoryTest extends TestCase
+{
+    /**
+     * @group 79
+     */
+    public function testInjectsLinksFromMetadataWhenCreatingEntity()
+    {
+        $object = new TestAsset\Entity('foo', 'Foo');
+
+        $metadata = new MetadataMap(array(
+            'ZFTest\Hal\Plugin\TestAsset\Entity' => array(
+                'hydrator'   => 'Zend\Stdlib\Hydrator\ObjectProperty',
+                'route_name' => 'hostname/resource',
+                'links'      => array(
+                    array(
+                        'rel' => 'describedby',
+                        'url' => 'http://example.com/api/help/resource',
+                    ),
+                    array(
+                        'rel' => 'children',
+                        'route' => array(
+                            'name' => 'resource/children',
+                        ),
+                    ),
+                ),
+            ),
+        ));
+
+        $resourceFactory = $this->getResourceFactory($metadata);
+
+        $entity = $resourceFactory->createEntityFromMetadata(
+            $object,
+            $metadata->get('ZFTest\Hal\Plugin\TestAsset\Entity')
+        );
+
+        $this->assertInstanceof('ZF\Hal\Entity', $entity);
+        $links = $entity->getLinks();
+        $this->assertTrue($links->has('describedby'));
+        $this->assertTrue($links->has('children'));
+
+        $describedby = $links->get('describedby');
+        $this->assertTrue($describedby->hasUrl());
+        $this->assertEquals('http://example.com/api/help/resource', $describedby->getUrl());
+
+        $children = $links->get('children');
+        $this->assertTrue($children->hasRoute());
+        $this->assertEquals('resource/children', $children->getRoute());
+    }
+
+    /**
+     * Test that the hal metadata route params config allows callables.
+     *
+     * All callables should be passed the object being used for entity creation.
+     * If closure binding is supported, any closures should be bound to that
+     * object.
+     *
+     * The return value should be used as the route param for the link (in
+     * place of the callable).
+     */
+    public function testRouteParamsAllowsCallable()
+    {
+        $object = new TestAsset\Entity('foo', 'Foo');
+
+        $callback = $this->getMock('stdClass', array('callback'));
+        $callback->expects($this->atLeastOnce())
+                 ->method('callback')
+                 ->with($this->equalTo($object))
+                 ->will($this->returnValue('callback-param'));
+
+        $test = $this;
+
+        $metadata = new MetadataMap(array(
+            'ZFTest\Hal\Plugin\TestAsset\Entity' => array(
+                'hydrator'     => 'Zend\Stdlib\Hydrator\ObjectProperty',
+                'route_name'   => 'hostname/resource',
+                'route_params' => array(
+                    'test-1' => array($callback, 'callback'),
+                    'test-2' => function ($expected) use ($object, $test) {
+                        $test->assertSame($expected, $object);
+                        if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
+                            $test->assertSame($object, $this);
+                        }
+
+                        return 'closure-param';
+                    },
+                ),
+            ),
+        ));
+
+        $resourceFactory = $this->getResourceFactory($metadata);
+
+        $entity = $resourceFactory->createEntityFromMetadata(
+            $object,
+            $metadata->get('ZFTest\Hal\Plugin\TestAsset\Entity')
+        );
+
+        $this->assertInstanceof('ZF\Hal\Entity', $entity);
+
+        $links = $entity->getLinks();
+        $this->assertTrue($links->has('self'));
+
+        $self = $links->get('self');
+        $params = $self->getRouteParams();
+
+        $this->assertArrayHasKey('test-1', $params);
+        $this->assertEquals('callback-param', $params['test-1']);
+
+        $this->assertArrayHasKey('test-2', $params);
+        $this->assertEquals('closure-param', $params['test-2']);
+    }
+
+    /**
+     * @group 79
+     */
+    public function testInjectsLinksFromMetadataWhenCreatingCollection()
+    {
+        $set = new TestAsset\Collection(array(
+            (object) array('id' => 'foo', 'name' => 'foo'),
+            (object) array('id' => 'bar', 'name' => 'bar'),
+            (object) array('id' => 'baz', 'name' => 'baz'),
+        ));
+
+        $metadata = new MetadataMap(array(
+            'ZFTest\Hal\Plugin\TestAsset\Collection' => array(
+                'is_collection'       => true,
+                'route_name'          => 'hostname/contacts',
+                'entity_route_name'   => 'hostname/embedded',
+                'links'               => array(
+                    array(
+                        'rel' => 'describedby',
+                        'url' => 'http://example.com/api/help/collection',
+                    ),
+                ),
+            ),
+        ));
+
+        $resourceFactory = $this->getResourceFactory($metadata);
+
+        $collection = $resourceFactory->createCollectionFromMetadata(
+            $set,
+            $metadata->get('ZFTest\Hal\Plugin\TestAsset\Collection')
+        );
+
+        $this->assertInstanceof('ZF\Hal\Collection', $collection);
+        $links = $collection->getLinks();
+        $this->assertTrue($links->has('describedby'));
+        $link = $links->get('describedby');
+        $this->assertTrue($link->hasUrl());
+        $this->assertEquals('http://example.com/api/help/collection', $link->getUrl());
+    }
+
+    private function getResourceFactory(MetadataMap $metadata)
+    {
+        $hydratorPluginManager = new HydratorPluginManager();
+        $entityHydratorManager = new EntityHydratorManager($hydratorPluginManager, $metadata);
+        $entityExtractor       = new EntityExtractor($entityHydratorManager);
+
+        return new ResourceFactory($entityHydratorManager, $entityExtractor);
+    }
+}


### PR DESCRIPTION
I added some classes with logic extracted from Hal plugin:
- `ZF\Hal\EntityHydratorManager`: Manage mapping of entity hydrators using metadata
- `ZF\Hal\ResourceFactory`: Create resources (entity, collection) using metadata
- `ZF\Hal\Extractor\EntityExtractor`: Extract entity data using associate hydrator defined in metadata

I also improve factories by using intermediate services to retrieve module configuration:
- `ZF\Hal\HalConfig`: Array containing Hal configuration
- `ZF\Hal\RendererOptions`: Class extending `Zend\Stdlib\AbstractOptions` with renderer properties