### PR TITLE
renderEntity.post is not triggered

### DIFF
--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -616,11 +616,18 @@ class Hal extends AbstractHelper implements
         $halEntity->setLinks($entityLinks);
         $entity['_links'] = $this->fromResource($halEntity);
 
+        $payload = new ArrayObject($entity);
+        $this->getEventManager()->trigger(
+            __FUNCTION__ . '.post',
+            $this,
+            array('payload' => $payload, 'entity' => $halEntity)
+        );
+
         if (isset($entityHash)) {
             unset($this->entityHashStack[$entityHash]);
         }
 
-        return $entity;
+        return $payload->getArrayCopy();
     }
 
     /**

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -2214,4 +2214,21 @@ class HalTest extends TestCase
             $this->assertEquals('bar', $item['foo']);
         }
     }
+
+    /**
+     * @group 100
+     */
+    public function testRenderEntityPostEventIsTriggered()
+    {
+        $entity = array('id' => 1, 'foo' => 'bar');
+        $halEntity = new Entity($entity, 1);
+
+        $triggered = false;
+        $this->plugin->getEventManager()->attach('renderEntity.post', function ($e) use (&$triggered) {
+            $triggered = true;
+        });
+
+        $this->plugin->renderEntity($halEntity);
+        $this->assertTrue($triggered);
+    }
 }


### PR DESCRIPTION
Doc says about renderEntity.post event which is actually never triggered.
Trigger has been removed within commit: b5daea44afa6d5360b998cb931252fda9676e3a3

Is it going to return at its place?