### PR TITLE
Use _links instead of unrendered embedded entity

### DIFF
--- a/src/Factory/HalViewHelperFactory.php
+++ b/src/Factory/HalViewHelperFactory.php
@@ -60,6 +60,9 @@ class HalViewHelperFactory implements FactoryInterface
 
         $helper->setRenderEmbeddedEntities($rendererOptions->getRenderEmbeddedEntities());
         $helper->setRenderCollections($rendererOptions->getRenderEmbeddedCollections());
+        $helper->setUseResourceLinksInsteadOfEmbeddedEntityLink(
+            $rendererOptions->getUseResourceLinksInsteadOfEmbeddedEntityLink()
+        );
 
         $hydratorMap = $rendererOptions->getHydrators();
         foreach ($hydratorMap as $class => $hydratorServiceName) {

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -78,6 +78,13 @@ class Hal extends AbstractHelper implements
     protected $renderCollections = true;
 
     /**
+     * When set to true embedded entities will will be created as _links members instead of inside _embedded.
+     * This option is only in effect when @see renderEmbeddedEntities is false
+     * @var bool
+     */
+    protected $useResourceLinksInsteadOfEmbeddedEntityLink = false;
+
+    /**
      * @var EventManagerInterface
      */
     protected $events;
@@ -479,6 +486,26 @@ class Hal extends AbstractHelper implements
     }
 
     /**
+     * Get boolean to use _links instead of embedding non-rendered (link-only) entities
+     *
+     * @return bool
+     */
+    public function getUseResourceLinksInsteadOfEmbeddedEntityLink()
+    {
+        return $this->useResourceLinksInsteadOfEmbeddedEntityLink;
+    }
+
+    /**
+     * Set boolean to use _links instead of embedding non-rendered (link-only) entities
+     *
+     * @param bool $flag
+     */
+    public function setUseResourceLinksInsteadOfEmbeddedEntityLink($flag)
+    {
+        $this->useResourceLinksInsteadOfEmbeddedEntityLink = (bool) $flag;
+    }
+
+    /**
      * Retrieve a hydrator for a given entity
      *
      * Please use getHydratorForEntity().
@@ -673,16 +700,29 @@ class Hal extends AbstractHelper implements
         }
 
         foreach ($entity as $key => $value) {
+            $valueMetadata = null;
             if (is_object($value) && $metadataMap->has($value)) {
+                $valueMetadata = $metadataMap->get($value);
                 $value = $this->getResourceFactory()->createEntityFromMetadata(
                     $value,
-                    $metadataMap->get($value),
+                    $valueMetadata,
                     $this->getRenderEmbeddedEntities()
                 );
             }
 
             if ($value instanceof Entity) {
-                $this->extractEmbeddedEntity($entity, $key, $value, $depth + 1, $maxDepth);
+                if($this->getRenderEmbeddedEntities() ||
+                    (!$this->getRenderEmbeddedEntities() && !$this->getUseResourceLinksInsteadOfEmbeddedEntityLink()))
+                {
+                    $this->extractEmbeddedEntity($entity, $key, $value, $depth + 1, $maxDepth);
+                }else{
+                    $value = $this->getResourceFactory()->marshalLinkFromMetadata(
+                        $valueMetadata,
+                        $value,
+                        $value->id,
+                        $valueMetadata->getRouteIdentifierName(),
+                        $key);
+                }
             }
             if ($value instanceof Collection) {
                 $this->extractEmbeddedCollection($entity, $key, $value, $depth + 1, $maxDepth);

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -716,18 +716,21 @@ class Hal extends AbstractHelper implements
             }
 
             if ($value instanceof Entity) {
-                if($this->getRenderEmbeddedEntities() ||
-                    (!$this->getRenderEmbeddedEntities() && !$this->getUseResourceLinksInsteadOfEmbeddedEntityLink()))
-                {
-                    $this->extractEmbeddedEntity($entity, $key, $value, $depth + 1, $maxDepth);
-                }else{
+                if (
+                    ( ! $this->getRenderEmbeddedEntities() && $this->getUseResourceLinksInsteadOfEmbeddedEntityLink())
+                    || ($this->getRenderEmbeddedEntities() && $depth >= $maxDepth)
+                ) {
                     $value = $this->getResourceFactory()->marshalLinkFromMetadata(
                         $valueMetadata,
                         $value,
                         $value->id,
                         $valueMetadata->getRouteIdentifierName(),
-                        $key);
+                        $key
+                    );
+                } else {
+                    $this->extractEmbeddedEntity($entity, $key, $value, $depth + 1, $maxDepth);
                 }
+
             }
             if ($value instanceof Collection) {
                 $this->extractEmbeddedCollection($entity, $key, $value, $depth + 1, $maxDepth);

--- a/src/RendererOptions.php
+++ b/src/RendererOptions.php
@@ -26,6 +26,14 @@ class RendererOptions extends AbstractOptions
     protected $renderEmbeddedCollections = true;
 
     /**
+     * When set to true embedded entities will will be created as _links members instead of inside _embedded.
+     * This option is only in effect when @see renderEmbeddedEntities is false. Defaulted to false for non-breaking
+     * compatibility concerns
+     * @var bool
+     */
+    protected $useResourceLinksInsteadOfEmbeddedEntityLink = false;
+
+    /**
      * @var array
      */
     protected $hydrators = [];
@@ -55,7 +63,7 @@ class RendererOptions extends AbstractOptions
     }
 
     /**
-     * @return string
+     * @return bool
      */
     public function getRenderEmbeddedEntities()
     {
@@ -71,11 +79,27 @@ class RendererOptions extends AbstractOptions
     }
 
     /**
-     * @return string
+     * @return bool
      */
     public function getRenderEmbeddedCollections()
     {
         return $this->renderEmbeddedCollections;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getUseResourceLinksInsteadOfEmbeddedEntityLink()
+    {
+        return $this->useResourceLinksInsteadOfEmbeddedEntityLink;
+    }
+
+    /**
+     * @param bool $flag
+     */
+    public function setUseResourceLinksInsteadOfEmbeddedEntityLink($flag)
+    {
+        $this->useResourceLinksInsteadOfEmbeddedEntityLink = (bool) $flag;
     }
 
     /**

--- a/src/ResourceFactory.php
+++ b/src/ResourceFactory.php
@@ -173,6 +173,10 @@ class ResourceFactory
             $params = array_merge($params, [$routeIdentifierName => $id]);
         }
 
+        if($relation !== 'self' && $id){
+            $link->setProps(array_merge($link->getProps(),['id' => $id]));
+        }
+
         $link->setRoute($metadata->getRoute(), $params, $metadata->getRouteOptions());
         return $link;
     }


### PR DESCRIPTION
This is an exploratory pull request to get feedback and explore a solution

Adding option to use the rendered resources _link object for related/embedded entities when render 
embedded resources is set to false.