### PR TITLE
Update stdlib version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "zendframework/zend-paginator": "~2.3",
         "zendframework/zend-uri": "~2.3",
         "zendframework/zend-view": "~2.3",
-        "zendframework/zend-stdlib": "~2.3"
+        "zendframework/zend-stdlib": ">=2.3.0,<2.7.0"
     },
     "require-dev": {
         "phpunit/PHPUnit": "4.7.*",


### PR DESCRIPTION
To < 2.7.0, to ensure only hydrators implementing the stdlib hydrator interfaces will work.