### PR TITLE
Extract link url building code

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -55,11 +55,14 @@ return [
     ],
     'service_manager' => [
         'factories' => [
-            'ZF\Hal\HalConfig'       => 'ZF\Hal\Factory\HalConfigFactory',
-            'ZF\Hal\JsonRenderer'    => 'ZF\Hal\Factory\HalJsonRendererFactory',
-            'ZF\Hal\JsonStrategy'    => 'ZF\Hal\Factory\HalJsonStrategyFactory',
-            'ZF\Hal\MetadataMap'     => 'ZF\Hal\Factory\MetadataMapFactory',
-            'ZF\Hal\RendererOptions' => 'ZF\Hal\Factory\RendererOptionsFactory',
+            'ZF\Hal\Extractor\LinkExtractor' => 'ZF\Hal\Factory\LinkExtractorFactory',
+            'ZF\Hal\Extractor\LinkCollectionExtractor' => 'ZF\Hal\Factory\LinkCollectionExtractorFactory',
+            'ZF\Hal\HalConfig'           => 'ZF\Hal\Factory\HalConfigFactory',
+            'ZF\Hal\JsonRenderer'        => 'ZF\Hal\Factory\HalJsonRendererFactory',
+            'ZF\Hal\JsonStrategy'        => 'ZF\Hal\Factory\HalJsonStrategyFactory',
+            'ZF\Hal\Link\LinkUrlBuilder' => 'ZF\Hal\Factory\LinkUrlBuilderFactory',
+            'ZF\Hal\MetadataMap'         => 'ZF\Hal\Factory\MetadataMapFactory',
+            'ZF\Hal\RendererOptions'     => 'ZF\Hal\Factory\RendererOptionsFactory',
         ],
     ],
     'view_helpers' => [

--- a/src/Extractor/LinkExtractor.php
+++ b/src/Extractor/LinkExtractor.php
@@ -6,47 +6,23 @@
 
 namespace ZF\Hal\Extractor;
 
-use Zend\View\Helper\Url;
-use Zend\View\Helper\ServerUrl;
 use ZF\ApiProblem\Exception\DomainException;
 use ZF\Hal\Link\Link;
+use ZF\Hal\Link\LinkUrlBuilder;
 
 class LinkExtractor implements LinkExtractorInterface
 {
     /**
-     * @var ServerUrl
+     * @var LinkUrlBuilder
      */
-    protected $serverUrlHelper;
+    protected $linkUrlBuilder;
 
     /**
-     * @var Url
+     * @param  LinkUrlBuilder $linkUrlBuilder
      */
-    protected $urlHelper;
-
-    /**
-     * @var string
-     */
-    protected $serverUrlString;
-
-    /**
-     * @param  ServerUrl $serverUrlHelper
-     * @param  Url $urlHelper
-     */
-    public function __construct(ServerUrl $serverUrlHelper, Url $urlHelper)
+    public function __construct(LinkUrlBuilder $linkUrlBuilder)
     {
-        $this->serverUrlHelper = $serverUrlHelper;
-        $this->urlHelper       = $urlHelper;
-    }
-
-    /**
-     * @return string
-     */
-    protected function getServerUrl()
-    {
-        if ($this->serverUrlString === null) {
-            $this->serverUrlString = call_user_func($this->serverUrlHelper);
-        }
-        return $this->serverUrlString;
+        $this->linkUrlBuilder = $linkUrlBuilder;
     }
 
     /**
@@ -76,19 +52,12 @@ class LinkExtractor implements LinkExtractorInterface
             unset($options['reuse_matched_params']);
         }
 
-        $path = call_user_func(
-            $this->urlHelper,
+        $representation['href'] = $this->linkUrlBuilder->buildLinkUrl(
             $object->getRoute(),
             $object->getRouteParams(),
             $options,
             $reuseMatchedParams
         );
-
-        if (substr($path, 0, 4) == 'http') {
-            $representation['href'] = $path;
-        } else {
-            $representation['href'] = $this->getServerUrl() . $path;
-        }
 
         return $representation;
     }

--- a/src/Factory/HalViewHelperFactory.php
+++ b/src/Factory/HalViewHelperFactory.php
@@ -9,8 +9,6 @@ namespace ZF\Hal\Factory;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use ZF\Hal\Exception;
-use ZF\Hal\Extractor\LinkCollectionExtractor;
-use ZF\Hal\Extractor\LinkExtractor;
 use ZF\Hal\Plugin;
 
 class HalViewHelperFactory implements FactoryInterface
@@ -22,27 +20,19 @@ class HalViewHelperFactory implements FactoryInterface
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         $services        = $serviceLocator->getServiceLocator();
-        $halConfig       = $services->get('ZF\Hal\HalConfig');
+
         /* @var $rendererOptions \ZF\Hal\RendererOptions */
         $rendererOptions = $services->get('ZF\Hal\RendererOptions');
         $metadataMap     = $services->get('ZF\Hal\MetadataMap');
         $hydrators       = $metadataMap->getHydratorManager();
 
-        $serverUrlHelper = $serviceLocator->get('ServerUrl');
-        if (isset($halConfig['options']['use_proxy'])) {
-            $serverUrlHelper->setUseProxy($halConfig['options']['use_proxy']);
-        }
-
-        $urlHelper = $serviceLocator->get('Url');
-
         $helper = new Plugin\Hal($hydrators);
-        $helper
-            ->setMetadataMap($metadataMap)
-            ->setServerUrlHelper($serverUrlHelper)
-            ->setUrlHelper($urlHelper);
+        $helper->setMetadataMap($metadataMap);
 
-        $linkExtractor = new LinkExtractor($serverUrlHelper, $urlHelper);
-        $linkCollectionExtractor = new LinkCollectionExtractor($linkExtractor);
+        $linkUrlBuilder = $services->get('ZF\Hal\Link\LinkUrlBuilder');
+        $helper->setLinkUrlBuilder($linkUrlBuilder);
+
+        $linkCollectionExtractor = $services->get('ZF\Hal\Extractor\LinkCollectionExtractor');
         $helper->setLinkCollectionExtractor($linkCollectionExtractor);
 
         $defaultHydrator = $rendererOptions->getDefaultHydrator();

--- a/src/Factory/LinkCollectionExtractorFactory.php
+++ b/src/Factory/LinkCollectionExtractorFactory.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Hal\Factory;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZF\Hal\Extractor\LinkCollectionExtractor;
+
+class LinkCollectionExtractorFactory implements FactoryInterface
+{
+    /**
+     * @param  ServiceLocatorInterface $serviceLocator
+     * @return LinkCollectionExtractor
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $linkExtractor = $serviceLocator->get('ZF\Hal\Extractor\LinkExtractor');
+
+        return new LinkCollectionExtractor($linkExtractor);
+    }
+}

--- a/src/Factory/LinkExtractorFactory.php
+++ b/src/Factory/LinkExtractorFactory.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Hal\Factory;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZF\Hal\Extractor\LinkExtractor;
+
+class LinkExtractorFactory implements FactoryInterface
+{
+    /**
+     * @param  ServiceLocatorInterface $serviceLocator
+     * @return LinkExtractor
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $linkUrlBuilder = $serviceLocator->get('ZF\Hal\Link\LinkUrlBuilder');
+
+        return new LinkExtractor($linkUrlBuilder);
+    }
+}

--- a/src/Factory/LinkUrlBuilderFactory.php
+++ b/src/Factory/LinkUrlBuilderFactory.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Hal\Factory;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZF\Hal\Link\LinkUrlBuilder;
+
+class LinkUrlBuilderFactory implements FactoryInterface
+{
+    /**
+     * @param  ServiceLocatorInterface $serviceLocator
+     * @return LinkUrlBuilder
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $halConfig = $serviceLocator->get('ZF\Hal\HalConfig');
+
+        $viewHelperManager = $serviceLocator->get('ViewHelperManager');
+
+        $serverUrlHelper = $viewHelperManager->get('ServerUrl');
+        if (isset($halConfig['options']['use_proxy'])) {
+            $serverUrlHelper->setUseProxy($halConfig['options']['use_proxy']);
+        }
+
+        $urlHelper = $viewHelperManager->get('Url');
+
+        return new LinkUrlBuilder($serverUrlHelper, $urlHelper);
+    }
+}

--- a/src/Link/LinkUrlBuilder.php
+++ b/src/Link/LinkUrlBuilder.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Hal\Link;
+
+use Zend\View\Helper\ServerUrl;
+use Zend\View\Helper\Url;
+
+class LinkUrlBuilder
+{
+    /**
+     * @var ServerUrl
+     */
+    protected $serverUrlHelper;
+
+    /**
+     * @var Url
+     */
+    protected $urlHelper;
+
+    /**
+     * @param ServerUrl $serverUrlHelper
+     * @param Url $urlHelper
+     */
+    public function __construct(ServerUrl $serverUrlHelper, Url $urlHelper)
+    {
+        $this->serverUrlHelper = $serverUrlHelper;
+        $this->urlHelper       = $urlHelper;
+    }
+
+    /**
+     * @param  string $route
+     * @param  array $params
+     * @param  array $options
+     * @param  bool $reUseMatchedParams
+     * @return string
+     */
+    public function buildLinkUrl($route, $params = [], $options = [], $reUseMatchedParams = false)
+    {
+        $path = call_user_func(
+            $this->urlHelper,
+            $route,
+            $params,
+            $options,
+            $reUseMatchedParams
+        );
+
+        if (substr($path, 0, 4) == 'http') {
+            return $path;
+        }
+
+        return call_user_func($this->serverUrlHelper, $path);
+    }
+}

--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -17,8 +17,6 @@ use Zend\Mvc\Controller\Plugin\PluginInterface as ControllerPluginInterface;
 use Zend\Paginator\Paginator;
 use Zend\Stdlib\DispatchableInterface;
 use Zend\View\Helper\AbstractHelper;
-use Zend\View\Helper\ServerUrl;
-use Zend\View\Helper\Url;
 use ZF\ApiProblem\ApiProblem;
 use ZF\Hal\Collection;
 use ZF\Hal\Entity;
@@ -29,6 +27,7 @@ use ZF\Hal\Extractor\LinkCollectionExtractorInterface;
 use ZF\Hal\Link\Link;
 use ZF\Hal\Link\LinkCollection;
 use ZF\Hal\Link\LinkCollectionAwareInterface;
+use ZF\Hal\Link\LinkUrlBuilder;
 use ZF\Hal\Link\PaginationInjector;
 use ZF\Hal\Link\PaginationInjectorInterface;
 use ZF\Hal\Metadata\Metadata;
@@ -98,14 +97,9 @@ class Hal extends AbstractHelper implements
     protected $paginationInjector;
 
     /**
-     * @var ServerUrl
+     * @var LinkUrlBuilder
      */
-    protected $serverUrlHelper;
-
-    /**
-     * @var Url
-     */
-    protected $urlHelper;
+    protected $linkUrlBuilder;
 
     /**
      * @var LinkCollectionExtractor
@@ -309,6 +303,16 @@ class Hal extends AbstractHelper implements
     }
 
     /**
+     * @param  LinkUrlBuilder $builder
+     * @return self
+     */
+    public function setLinkUrlBuilder(LinkUrlBuilder $builder)
+    {
+        $this->linkUrlBuilder = $builder;
+        return $this;
+    }
+
+    /**
      * @return PaginationInjectorInterface
      */
     public function getPaginationInjector()
@@ -326,26 +330,6 @@ class Hal extends AbstractHelper implements
     public function setPaginationInjector(PaginationInjectorInterface $injector)
     {
         $this->paginationInjector = $injector;
-        return $this;
-    }
-
-    /**
-     * @param ServerUrl $helper
-     * @return self
-     */
-    public function setServerUrlHelper(ServerUrl $helper)
-    {
-        $this->serverUrlHelper = $helper;
-        return $this;
-    }
-
-    /**
-     * @param Url $helper
-     * @return self
-     */
-    public function setUrlHelper(Url $helper)
-    {
-        $this->urlHelper = $helper;
         return $this;
     }
 
@@ -751,18 +735,12 @@ class Hal extends AbstractHelper implements
         ]);
         $events->trigger(__FUNCTION__, $this, $eventParams);
 
-        $path = call_user_func(
-            $this->urlHelper,
-            $eventParams['route'],
+        return $this->linkUrlBuilder->buildLinkUrl(
+            $route,
             $params->getArrayCopy(),
+            [],
             $reUseMatchedParams
         );
-
-        if (substr($path, 0, 4) == 'http') {
-            return $path;
-        }
-
-        return call_user_func($this->serverUrlHelper, $path);
     }
 
     /**

--- a/test/ChildEntitiesIntegrationTest.php
+++ b/test/ChildEntitiesIntegrationTest.php
@@ -19,6 +19,7 @@ use ZF\Hal\Entity;
 use ZF\Hal\Extractor\LinkCollectionExtractor;
 use ZF\Hal\Extractor\LinkExtractor;
 use ZF\Hal\Link\Link;
+use ZF\Hal\Link\LinkUrlBuilder;
 use ZF\Hal\Plugin\Hal as HalHelper;
 use ZF\Hal\View\HalJsonModel;
 use ZF\Hal\View\HalJsonRenderer;
@@ -48,11 +49,12 @@ class ChildEntitiesIntegrationTest extends TestCase
         $serverUrlHelper->setScheme('http');
         $serverUrlHelper->setHost('localhost.localdomain');
 
-        $linksHelper = new HalHelper();
-        $linksHelper->setUrlHelper($urlHelper);
-        $linksHelper->setServerUrlHelper($serverUrlHelper);
+        $linkUrlBuilder = new LinkUrlBuilder($serverUrlHelper, $urlHelper);
 
-        $linkExtractor = new LinkExtractor($serverUrlHelper, $urlHelper);
+        $linksHelper = new HalHelper();
+        $linksHelper->setLinkUrlBuilder($linkUrlBuilder);
+
+        $linkExtractor = new LinkExtractor($linkUrlBuilder);
         $linkCollectionExtractor = new LinkCollectionExtractor($linkExtractor);
         $linksHelper->setLinkCollectionExtractor($linkCollectionExtractor);
 

--- a/test/Extractor/LinkExtractorTest.php
+++ b/test/Extractor/LinkExtractorTest.php
@@ -13,15 +13,17 @@ use Zend\Mvc\Router\RouteMatch;
 use Zend\View\Helper\Url as UrlHelper;
 use ZF\Hal\Extractor\LinkExtractor;
 use ZF\Hal\Link\Link;
+use ZF\Hal\Link\LinkUrlBuilder;
 
 class LinkExtractorTest extends TestCase
 {
     public function testExtractGivenIncompleteLinkShouldThrowException()
     {
-        $serverUrlHelper = $this->getMock('Zend\View\Helper\ServerUrl');
-        $urlHelper       = $this->getMock('Zend\View\Helper\Url');
+        $linkUrlBuilder = $this->getMockBuilder('ZF\Hal\Link\LinkUrlBuilder')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $linkExtractor = new LinkExtractor($serverUrlHelper, $urlHelper);
+        $linkExtractor = new LinkExtractor($linkUrlBuilder);
 
         $link = $this->getMockBuilder('ZF\Hal\Link\Link')
             ->disableOriginalConstructor()
@@ -38,10 +40,11 @@ class LinkExtractorTest extends TestCase
 
     public function testExtractGivenLinkWithUrlShouldReturnThisOne()
     {
-        $serverUrlHelper = $this->getMock('Zend\View\Helper\ServerUrl');
-        $urlHelper       = $this->getMock('Zend\View\Helper\Url');
+        $linkUrlBuilder = $this->getMockBuilder('ZF\Hal\Link\LinkUrlBuilder')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $linkExtractor = new LinkExtractor($serverUrlHelper, $urlHelper);
+        $linkExtractor = new LinkExtractor($linkUrlBuilder);
 
         $params = [
             'rel' => 'resource',
@@ -56,10 +59,11 @@ class LinkExtractorTest extends TestCase
 
     public function testExtractShouldComposeAnyPropertiesInLink()
     {
-        $serverUrlHelper = $this->getMock('Zend\View\Helper\ServerUrl');
-        $urlHelper       = $this->getMock('Zend\View\Helper\Url');
+        $linkUrlBuilder = $this->getMockBuilder('ZF\Hal\Link\LinkUrlBuilder')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $linkExtractor = new LinkExtractor($serverUrlHelper, $urlHelper);
+        $linkExtractor = new LinkExtractor($linkUrlBuilder);
 
         $link = Link::factory([
             'rel'   => 'resource',
@@ -87,7 +91,9 @@ class LinkExtractorTest extends TestCase
         $serverUrlHelper = $this->getMock('Zend\View\Helper\ServerUrl');
         $urlHelper       = new UrlHelper;
 
-        $linkExtractor = new LinkExtractor($serverUrlHelper, $urlHelper);
+        $linkUrlBuilder = new LinkUrlBuilder($serverUrlHelper, $urlHelper);
+
+        $linkExtractor = new LinkExtractor($linkUrlBuilder);
 
         $match = $this->matchUrl('/resource/foo', $urlHelper);
         $this->assertEquals('foo', $match->getParam('id', false));

--- a/test/Factory/HalViewHelperFactoryTest.php
+++ b/test/Factory/HalViewHelperFactoryTest.php
@@ -7,28 +7,29 @@
 namespace ZFTest\Hal\Factory;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use ReflectionObject;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Hydrator\HydratorPluginManager;
-use Zend\View\Helper\ServerUrl;
-use Zend\View\Helper\Url;
 use ZF\Hal\Factory\HalViewHelperFactory;
 use ZF\Hal\RendererOptions;
 
 class HalViewHelperFactoryTest extends TestCase
 {
-    public function setupPluginManager($config = [])
+    public function testInstantiatesHalViewHelper()
+    {
+        $pluginManager = $this->getPluginManager();
+
+        $factory = new HalViewHelperFactory();
+        $plugin = $factory->createService($pluginManager);
+
+        $this->assertInstanceOf('ZF\Hal\Plugin\Hal', $plugin);
+    }
+
+    private function getPluginManager()
     {
         $services = new ServiceManager();
 
-        $services->setService('ZF\Hal\HalConfig', $config);
-
-        if (isset($config['renderer']) && is_array($config['renderer'])) {
-            $rendererOptions = new RendererOptions($config['renderer']);
-        } else {
-            $rendererOptions = new RendererOptions();
-        }
-        $services->setService('ZF\Hal\RendererOptions', $rendererOptions);
+        $services->setService('ZF\Hal\HalConfig', []);
+        $services->setService('ZF\Hal\RendererOptions', new RendererOptions());
 
         $metadataMap = $this->getMock('ZF\Hal\Metadata\MetadataMap');
         $metadataMap
@@ -38,62 +39,21 @@ class HalViewHelperFactoryTest extends TestCase
 
         $services->setService('ZF\Hal\MetadataMap', $metadataMap);
 
-        $this->pluginManager = $this->getMock('Zend\ServiceManager\AbstractPluginManager');
+        $linkUrlBuilder = $this->getMockBuilder('ZF\Hal\Link\LinkUrlBuilder')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $services->setService('ZF\Hal\Link\LinkUrlBuilder', $linkUrlBuilder);
 
-        $this->pluginManager
-            ->expects($this->at(1))
-            ->method('get')
-            ->with('ServerUrl')
-            ->will($this->returnValue(new ServerUrl()));
+        $linkCollectionExtractor = $this->getMockBuilder('ZF\Hal\Extractor\LinkCollectionExtractor')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $services->setService('ZF\Hal\Extractor\LinkCollectionExtractor', $linkCollectionExtractor);
 
-        $this->pluginManager
-            ->expects($this->at(2))
-            ->method('get')
-            ->with('Url')
-            ->will($this->returnValue(new Url()));
-
-        $this->pluginManager
+        $pluginManager = $this->getMock('Zend\ServiceManager\AbstractPluginManager');
+        $pluginManager
             ->method('getServiceLocator')
             ->will($this->returnValue($services));
-    }
 
-    public function testInstantiatesHalViewHelper()
-    {
-        $this->setupPluginManager();
-
-        $factory = new HalViewHelperFactory();
-        $plugin = $factory->createService($this->pluginManager);
-
-        $this->assertInstanceOf('ZF\Hal\Plugin\Hal', $plugin);
-    }
-
-    /**
-     * @group fail
-     */
-    public function testOptionUseProxyIfPresentInConfig()
-    {
-        $options = [
-            'options' => [
-                'use_proxy' => true,
-            ],
-        ];
-
-        $this->setupPluginManager($options);
-
-        $factory = new HalViewHelperFactory();
-        $halPlugin = $factory->createService($this->pluginManager);
-
-        $r = new ReflectionObject($halPlugin);
-        $p = $r->getProperty('serverUrlHelper');
-        $p->setAccessible(true);
-        $serverUrlPlugin = $p->getValue($halPlugin);
-        $this->assertInstanceOf('Zend\View\Helper\ServerUrl', $serverUrlPlugin);
-
-        $r = new ReflectionObject($serverUrlPlugin);
-        $p = $r->getProperty('useProxy');
-        $p->setAccessible(true);
-        $useProxy = $p->getValue($serverUrlPlugin);
-        $this->assertInternalType('boolean', $useProxy);
-        $this->assertTrue($useProxy);
+        return $pluginManager;
     }
 }

--- a/test/Factory/LinkUrlBuilderFactoryTest.php
+++ b/test/Factory/LinkUrlBuilderFactoryTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Hal\Factory;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\ServiceManager\ServiceManager;
+use ZF\Hal\Factory\LinkUrlBuilderFactory;
+
+class LinkUrlBuilderFactoryTest extends TestCase
+{
+    public function testInstantiatesLinkUrlBuilder()
+    {
+        $serviceManager = $this->getServiceManager();
+
+        $factory = new LinkUrlBuilderFactory();
+        $builder = $factory->createService($serviceManager);
+
+        $this->assertInstanceOf('ZF\Hal\Link\LinkUrlBuilder', $builder);
+    }
+
+    public function testOptionUseProxyIfPresentInConfig()
+    {
+        $options = [
+            'options' => [
+                'use_proxy' => true,
+            ],
+        ];
+        $serviceManager = $this->getServiceManager($options);
+
+        $viewHelperManager = $serviceManager->get('ViewHelperManager');
+        $serverUrlHelper = $viewHelperManager->get('ServerUrl');
+
+        $serverUrlHelper
+            ->expects($this->once())
+            ->method('setUseProxy')
+            ->with($options['options']['use_proxy']);
+
+        $factory = new LinkUrlBuilderFactory();
+        $factory->createService($serviceManager);
+    }
+
+    private function getServiceManager($config = [])
+    {
+        $serviceManager = new ServiceManager();
+
+        $serviceManager->setService('ZF\Hal\HalConfig', $config);
+
+        $viewHelperManager = new ServiceManager();
+        $serviceManager->setService('ViewHelperManager', $viewHelperManager);
+
+        $serverUrlHelper = $this->getMock('Zend\View\Helper\ServerUrl');
+        $viewHelperManager->setService('ServerUrl', $serverUrlHelper);
+
+        $urlHelper = $this->getMock('Zend\View\Helper\Url');
+        $viewHelperManager->setService('Url', $urlHelper);
+
+        return $serviceManager;
+    }
+}

--- a/test/Plugin/HalTest.php
+++ b/test/Plugin/HalTest.php
@@ -19,11 +19,11 @@ use Zend\View\Helper\Url as UrlHelper;
 use Zend\View\Helper\ServerUrl as ServerUrlHelper;
 use ZF\Hal\Collection;
 use ZF\Hal\Entity;
-use ZF\Hal\EntityHydratorManager;
 use ZF\Hal\Extractor\LinkCollectionExtractor;
 use ZF\Hal\Extractor\LinkExtractor;
 use ZF\Hal\Link\Link;
 use ZF\Hal\Link\LinkCollection;
+use ZF\Hal\Link\LinkUrlBuilder;
 use ZF\Hal\Metadata\MetadataMap;
 use ZF\Hal\Plugin\Hal as HalHelper;
 use ZFTest\Hal\TestAsset as HalTestAsset;
@@ -111,10 +111,11 @@ class HalTest extends TestCase
 
         $this->plugin = $plugin = new HalHelper();
         $plugin->setController($controller);
-        $plugin->setUrlHelper($urlHelper);
-        $plugin->setServerUrlHelper($serverUrlHelper);
 
-        $linkExtractor = new LinkExtractor($serverUrlHelper, $urlHelper);
+        $linkUrlBuilder = new LinkUrlBuilder($serverUrlHelper, $urlHelper);
+        $plugin->setLinkUrlBuilder($linkUrlBuilder);
+
+        $linkExtractor = new LinkExtractor($linkUrlBuilder);
         $linkCollectionExtractor = new LinkCollectionExtractor($linkExtractor);
         $plugin->setLinkCollectionExtractor($linkCollectionExtractor);
     }


### PR DESCRIPTION
- extract link url building logic into specific class
- fix parameters used when using url helper in Hal plugin (missing `options` param)
- remove reflection usage in unit tests

These changes prevent to have view helpers, used to generate urls, as dependencies of several classes and keep the url building logic in only one place.