### PR TITLE
Added public method for resetting the entity hash stack.

### DIFF
--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -1193,6 +1193,14 @@ class Hal extends AbstractHelper implements
     }
 
     /**
+     * Reset entity hash stack
+     */
+    public function resetEntityHashStack()
+    {
+        $this->entityHashStack = [];
+    }
+
+    /**
      * Convert an individual entity to an array
      *
      * @deprecated


### PR DESCRIPTION
We need to render multiple responses for several users in the same `Hal` plugin instance.
Currently this isn't possible to do this because we cannot reset the `$entityHashStack`.
I added a public method to be able to reset the hash stack.