### PR TITLE
zend-hydrator v1.1 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "zendframework/zend-eventmanager": "^2.6.3 || ^3.0.1",
         "zendframework/zend-filter": "^2.7.1",
         "zendframework/zend-http": "^2.5.4",
-        "zendframework/zend-hydrator": "^2.2.1",
+        "zendframework/zend-hydrator": "^1.1 || ^2.2.1",
         "zendframework/zend-mvc": "^2.7.9 || ^3.0.2",
         "zendframework/zend-paginator": "^2.7",
         "zendframework/zend-uri": "^2.5.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "085e2c3a6e9fe8d268f962f91c3459e1",
-    "content-hash": "70f275061dd838fb0cb7d0af8abb8142",
+    "hash": "697c5d0094812f68a21259f9a5a81494",
+    "content-hash": "d6edc6fb0077437f46ecf1b7e0c9b7ef",
     "packages": [
         {
             "name": "container-interop/container-interop",


### PR DESCRIPTION
zend-hydrator v1.1 seems to be compatible with zf-hal, so I downgraded the minimum version to allow ^1.1.
I don't know why it was updated to ^2.2.1.
Anyone see some problem?