### PR TITLE
Fixed missing FactoryInterface allowing zend-servicemanager v2

### DIFF
--- a/src/Factory/HalControllerPluginFactory.php
+++ b/src/Factory/HalControllerPluginFactory.php
@@ -7,17 +7,36 @@
 namespace ZF\Hal\Factory;
 
 use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 use ZF\Hal\Plugin\Hal;
 
-class HalControllerPluginFactory
+class HalControllerPluginFactory implements FactoryInterface
 {
     /**
-     * @param ContainerInterface $container
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
      * @return Hal
      */
-    public function __invoke(ContainerInterface $container)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         $helpers  = $container->get('ViewHelperManager');
         return $helpers->get('Hal');
+    }
+
+    /**
+     * Create service
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return Hal
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        if ($serviceLocator instanceof AbstractPluginManager) {
+            $serviceLocator = $serviceLocator->getServiceLocator();
+        }
+        return $this($serviceLocator, Hal::class);
     }
 }

--- a/test/Factory/HalControllerPluginFactoryTest.php
+++ b/test/Factory/HalControllerPluginFactoryTest.php
@@ -8,7 +8,6 @@ namespace ZFTest\Hal\Factory;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Hydrator\HydratorPluginManager;
-use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\ServiceManager;
 use ZF\Hal\Factory\HalControllerPluginFactory;
 use ZF\Hal\Plugin\Hal as HalPlugin;
@@ -30,6 +29,32 @@ class HalControllerPluginFactoryTest extends TestCase
 
         $factory = new HalControllerPluginFactory();
         $plugin = $factory($services, 'Hal');
+
+        $this->assertInstanceOf('ZF\Hal\Plugin\Hal', $plugin);
+    }
+
+    public function testInstantiatesHalJsonRendererWithV2()
+    {
+        $viewHelperManager = $this->getMockBuilder('Zend\View\HelperPluginManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $viewHelperManager
+            ->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue(new HalPlugin(new HydratorPluginManager(new ServiceManager()))));
+
+        $services = new ServiceManager();
+        $services->setService('ViewHelperManager', $viewHelperManager);
+
+        $pluginManager = $this->getMockBuilder('Zend\ServiceManager\AbstractPluginManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $pluginManager->expects($this->once())
+            ->method('getServiceLocator')
+            ->willReturn($services);
+
+        $factory = new HalControllerPluginFactory();
+        $plugin = $factory->createService($pluginManager);
 
         $this->assertInstanceOf('ZF\Hal\Plugin\Hal', $plugin);
     }


### PR DESCRIPTION
This PR fixes the last missing FactoryInterface that allows the use of v2.