### PR TITLE
Updated to provide backwards compatibility

### DIFF
--- a/src/Factory/HalControllerPluginFactory.php
+++ b/src/Factory/HalControllerPluginFactory.php
@@ -7,6 +7,7 @@
 namespace ZF\Hal\Factory;
 
 use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\AbstractPluginManager;
 use ZF\Hal\Plugin\Hal;
 
 class HalControllerPluginFactory
@@ -17,6 +18,10 @@ class HalControllerPluginFactory
      */
     public function __invoke(ContainerInterface $container)
     {
+        $container = ($container instanceof AbstractPluginManager)
+            ? $container->getServiceLocator()
+            : $container;
+
         $helpers  = $container->get('ViewHelperManager');
         return $helpers->get('Hal');
     }


### PR DESCRIPTION
> Service "ViewHelperManager" has been requested to plugin manager of type "Zend\Mvc\Controller\PluginManager", but couldn't be retrieved.
> A previous exception of type "Zend\ServiceManager\Exception\ServiceNotFoundException" has been raised in the process.
> By the way, a service with the name "ViewHelperManager" has been found in the parent service locator "Zend\ServiceManager\ServiceManager": did you forget to use $parentLocator = $serviceLocator->getServiceLocator() in your factory code?