### PR TITLE
#160 fixed missing SharedEventManager with zend-eventmanager 3

### DIFF
--- a/src/Factory/HalViewHelperFactory.php
+++ b/src/Factory/HalViewHelperFactory.php
@@ -31,6 +31,11 @@ class HalViewHelperFactory
         $hydrators       = $metadataMap->getHydratorManager();
 
         $helper = new Plugin\Hal($hydrators);
+
+        if ($container->has('EventManager')) {
+            $helper->setEventManager($container->get('EventManager'));
+        }
+
         $helper->setMetadataMap($metadataMap);
 
         $linkUrlBuilder = $container->get(Link\LinkUrlBuilder::class);

--- a/test/Factory/HalViewHelperFactoryTest.php
+++ b/test/Factory/HalViewHelperFactoryTest.php
@@ -7,18 +7,26 @@
 namespace ZFTest\Hal\Factory;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use ReflectionObject;
+use Zend\EventManager\EventManagerInterface;
+use Zend\EventManager\SharedEventManagerInterface;
 use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Hydrator\HydratorPluginManager;
 use ZF\Hal\Extractor\LinkCollectionExtractor;
 use ZF\Hal\Link;
 use ZF\Hal\Factory\HalViewHelperFactory;
+use ZF\Hal\Plugin\Hal;
 use ZF\Hal\RendererOptions;
 
 class HalViewHelperFactoryTest extends TestCase
 {
+    /**
+     * @var AbstractPluginManager
+     */
     private $pluginManager;
+    /**
+     * @var ServiceManager
+     */
     private $services;
 
     public function setupPluginManager($config = [])
@@ -63,9 +71,19 @@ class HalViewHelperFactoryTest extends TestCase
     {
         $this->setupPluginManager();
 
+        $sharedEventManager = $this->getMockBuilder(SharedEventManagerInterface::class)
+            ->getMock();
+        $eventManagerMock = $this->getMockBuilder(EventManagerInterface::class)
+            ->getMock();
+        $eventManagerMock->method('getSharedManager')->willReturn($sharedEventManager);
+
+        $this->services->setService('EventManager', $eventManagerMock);
+
         $factory = new HalViewHelperFactory();
+        /** @var Hal $plugin */
         $plugin = $factory($this->services, 'Hal');
 
         $this->assertInstanceOf('ZF\Hal\Plugin\Hal', $plugin);
+        $this->assertInstanceOf(SharedEventManagerInterface::class, $plugin->getEventManager()->getSharedManager());
     }
 }


### PR DESCRIPTION
Fix for #160.

We inject the EventManager in Hal factory, before the `EventManagerAwareInitializer`.

In this way, the `EventManagerAwareInitializer` will not override the event manager and will be possibile to attach listeners in delegator factories.
