### PR TITLE
Add basic functionality for URI templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,10 @@ The `links` property is an array of arrays, each with the following structure:
     'rel'   => 'link relation',
     'url'   => 'string absolute URI to use', // OR
     'route' => [
-        'name'    => 'route name for this link',
-        'params'  => [ /* any route params to use for link generation */ .,
-        'options' => [ /* any options to pass to the router */ .,
+        'name'        => 'route name for this link',
+        'params'      => [ /* any route params to use for link generation */ .,
+        'options'     => [ /* any options to pass to the router */ .,
+        'uriTemplate' => [ /* see below */ .,
     .,
 .,
 // repeat as needed for any additional relational links
@@ -127,6 +128,16 @@ For now we have only one option available who contains the following configurati
 - `use_proxy` - boolean; set to `true` when you are using a proxy (for using
   `HTTP_X_FORWARDED_PROTO`, `HTTP_X_FORWARDED_HOST`, and
   `HTTP_X_FORWARDED_PORT` instead of `SSL_HTTPS`, `HTTP_HOST, SERVER_PORT`)
+
+#### Key: `uriTemplate`
+
+The uriTemplate key is used to configure some basic URI templates to be attached to the URL.
+For now we have two options available:
+
+- `query` - array; an array of values that will be attached as comma-separated list to the end of the URL
+            (e.g. `'uriTemplate' => ['query' => ['id', 'uid']],` leads to `{?id,uid}` being attached to the URL.)
+- `pathSegment` - array; an array of values that will be attached as in order as path segments to the end of the URL
+            (e.g. `'uriTemplate' => ['pathSegment' => ['id', 'uid']],` leads to `/{id}/{uid}` being attached to the URL.)
 
 ### System Configuration
 

--- a/docs/ref/metadata-map.rst
+++ b/docs/ref/metadata-map.rst
@@ -69,7 +69,7 @@ The following options are available for metadata maps:
   collection. Each item in the array is itself an array, with the required key
   "rel" (describing the relation), and one of either "url" (a string) or "route"
   (an array with the members: "name", required; "params", an array, optional;
-  and "options", an array, optional). (**OPTIONAL**)
+  "options", an array, optional; and "uriTemplate", an array, optional). (**OPTIONAL**)
 - **resource_route**: the name of the route to use for resources embedded as part
   of a collection. If not set, the route for the resource is used. (**OPTIONAL**)
 - **route**: the name of the route to use for generating the "self" relational

--- a/src/Extractor/LinkExtractor.php
+++ b/src/Extractor/LinkExtractor.php
@@ -40,7 +40,7 @@ class LinkExtractor implements LinkExtractorInterface
         $representation = $object->getProps();
 
         if ($object->hasUrl()) {
-            $representation['href'] = $object->getUrl();
+            $representation['href'] = $object->getUrl() . $object->getFormattedUriTemplate();
 
             return $representation;
         }
@@ -57,7 +57,7 @@ class LinkExtractor implements LinkExtractorInterface
             $object->getRouteParams(),
             $options,
             $reuseMatchedParams
-        );
+        ) . $object->getFormattedUriTemplate();
 
         return $representation;
     }

--- a/src/Link/Link.php
+++ b/src/Link/Link.php
@@ -49,6 +49,11 @@ class Link
     protected $url;
 
     /**
+     * @var UriTemplate
+     */
+    protected $uriTemplate;
+
+    /**
      * Create a link relation
      *
      * @todo  filtering and/or validation of relation string
@@ -80,6 +85,22 @@ class Link
             && is_array($spec['props'])
         ) {
             $link->setProps($spec['props']);
+        }
+
+        if (isset($spec['uriTemplate'])) {
+            $uriTemplateSpec = $spec['uriTemplate'];
+            if (count($uriTemplateSpec) > 1) {
+                throw new Exception\InvalidArgumentException(sprintf(
+                    '%s requires that the specification array\'s "uriTemplate" array contains at most one parameter',
+                    __METHOD__
+                ));
+            }
+
+            if (isset($uriTemplateSpec['query']) && is_array($uriTemplateSpec['query'])) {
+                $link->setUriTemplate(UriTemplate::withQueryParameters($uriTemplateSpec['query']));
+            } elseif (isset($uriTemplateSpec['pathSegment']) && is_array($uriTemplateSpec['pathSegment'])) {
+                $link->setUriTemplate(UriTemplate::withPathSegmentParameters($uriTemplateSpec['pathSegment']));
+            }
         }
 
         if (isset($spec['url'])) {
@@ -256,6 +277,14 @@ class Link
     }
 
     /**
+     * @param UriTemplate $uriTemplate
+     */
+    public function setUriTemplate($uriTemplate)
+    {
+        $this->uriTemplate = $uriTemplate;
+    }
+
+    /**
      * Get additional properties to include in Link representation
      *
      * @return array
@@ -313,6 +342,17 @@ class Link
     public function getUrl()
     {
         return $this->url;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFormattedUriTemplate()
+    {
+        if ($this->uriTemplate !== null) {
+            return $this->uriTemplate->getFormattedString();
+        }
+        return '';
     }
 
     /**

--- a/src/Link/UriTemplate.php
+++ b/src/Link/UriTemplate.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Hal\Link;
+
+
+class UriTemplate
+{
+    /** @var array */
+    private $queryParameters = [];
+
+    /** @var array */
+    private $pathSegmentParameters = [];
+
+    protected function __construct()
+    {
+    }
+
+    /**
+     * @param array $queryParameters
+     * @return UriTemplate
+     */
+    public static function withQueryParameters(array $queryParameters)
+    {
+        $template = new self();
+        $template->queryParameters = $queryParameters;
+
+        return $template;
+    }
+
+    /**
+     * @param array $pathSegmentParameters
+     * @return UriTemplate
+     */
+    public static function withPathSegmentParameters(array $pathSegmentParameters)
+    {
+        $template = new self();
+        $template->pathSegmentParameters = $pathSegmentParameters;
+
+        return $template;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFormattedString()
+    {
+        if (!empty($this->queryParameters)) {
+            return '{?' . implode(',', $this->queryParameters) . '}';
+        }
+        if (!empty($this->pathSegmentParameters)) {
+            return '/{' . implode('}/{', $this->pathSegmentParameters) . '}';
+        }
+        return '';
+    }
+
+}

--- a/src/Link/UriTemplate.php
+++ b/src/Link/UriTemplate.php
@@ -6,7 +6,6 @@
 
 namespace ZF\Hal\Link;
 
-
 class UriTemplate
 {
     /** @var array */
@@ -56,5 +55,4 @@ class UriTemplate
         }
         return '';
     }
-
 }

--- a/test/Extractor/LinkExtractorTest.php
+++ b/test/Extractor/LinkExtractorTest.php
@@ -59,6 +59,26 @@ class LinkExtractorTest extends TestCase
         $this->assertEquals($params['url'], $result['href']);
     }
 
+    public function testExtractGivenLinkWithUrlAndUriTemplateShouldReturnUrlWithTemplate()
+    {
+        $linkUrlBuilder = $this->getMockBuilder('ZF\Hal\Link\LinkUrlBuilder')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $linkExtractor = new LinkExtractor($linkUrlBuilder);
+
+        $params = [
+            'rel' => 'resource',
+            'url' => 'http://api.example.com',
+            'uriTemplate' => ['query' => ['id']],
+        ];
+        $link = Link::factory($params);
+
+        $result = $linkExtractor->extract($link);
+
+        $this->assertEquals('http://api.example.com{?id}', $result['href']);
+    }
+
     public function testExtractShouldComposeAnyPropertiesInLink()
     {
         $linkUrlBuilder = $this->getMockBuilder('ZF\Hal\Link\LinkUrlBuilder')

--- a/test/Link/UriTemplateTest.php
+++ b/test/Link/UriTemplateTest.php
@@ -11,18 +11,17 @@ use PHPUnit_Framework_TestCase as TestCase;
 
 class UriTemplateTest extends TestCase
 {
-    public function testReturnsFormattedQueryStringWhenGettingFormattedStringForUriTemplateWithQueryParameters()
+    public function testReturnsFormattedQueryStringWhenGettingUriTemplateStringWithQueryParameters()
     {
         $uriTemplate = UriTemplate::withQueryParameters(['id', 'tmp']);
 
         $this->assertSame('{?id,tmp}', $uriTemplate->getFormattedString());
     }
 
-    public function testReturnsFormattedPathSegmentStringWhenGettingFormattedStringForUriTemplateWithPathSegmentParameters()
+    public function testReturnsFormattedPathSegmentStringWhenGettingUriTemplateStringWithPathSegmentParameters()
     {
         $uriTemplate = UriTemplate::withPathSegmentParameters(['id', 'tmp']);
 
         $this->assertSame('/{id}/{tmp}', $uriTemplate->getFormattedString());
     }
-
 }

--- a/test/Link/UriTemplateTest.php
+++ b/test/Link/UriTemplateTest.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Hal\Link;
+
+use ZF\Hal\Link\UriTemplate;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class UriTemplateTest extends TestCase
+{
+    public function testReturnsFormattedQueryStringWhenGettingFormattedStringForUriTemplateWithQueryParameters()
+    {
+        $uriTemplate = UriTemplate::withQueryParameters(['id', 'tmp']);
+
+        $this->assertSame('{?id,tmp}', $uriTemplate->getFormattedString());
+    }
+
+    public function testReturnsFormattedPathSegmentStringWhenGettingFormattedStringForUriTemplateWithPathSegmentParameters()
+    {
+        $uriTemplate = UriTemplate::withPathSegmentParameters(['id', 'tmp']);
+
+        $this->assertSame('/{id}/{tmp}', $uriTemplate->getFormattedString());
+    }
+
+}


### PR DESCRIPTION
Add possibility to define two basic URI templates to append at the end of URL of links:
1. a query in form of '{?id,id2}'
2. a path segment in form of '/{id}/{id2}"