### PR TITLE
Changed to native JsonSerializable interface.

### DIFF
--- a/test/Plugin/TestAsset/JsonSerializableEntity.php
+++ b/test/Plugin/TestAsset/JsonSerializableEntity.php
@@ -10,11 +10,6 @@ use JsonSerializable;
 
 class JsonSerializableEntity extends Entity implements JsonSerializable
 {
-    public function __construct($id, $name)
-    {
-        parent::__construct($id, $name);
-    }
-
     public function jsonSerialize()
     {
         return [

--- a/test/Plugin/TestAsset/JsonSerializableEntity.php
+++ b/test/Plugin/TestAsset/JsonSerializableEntity.php
@@ -6,14 +6,13 @@
 
 namespace ZFTest\Hal\Plugin\TestAsset;
 
-use Zend\Stdlib\JsonSerializable;
+use JsonSerializable;
 
 class JsonSerializableEntity extends Entity implements JsonSerializable
 {
     public function __construct($id, $name)
     {
-        $this->id   = $id;
-        $this->name = $name;
+        parent::__construct($id, $name);
     }
 
     public function jsonSerialize()


### PR DESCRIPTION
Changed to native JsonSerializable interface, the Stlib interface has been deprecated Since 3.1.0; 
Called parent constructor