### PR TITLE
added trigger for pre-event in fromLink()

### DIFF
--- a/src/Plugin/Hal.php
+++ b/src/Plugin/Hal.php
@@ -791,6 +791,8 @@ class Hal extends AbstractHelper implements
      */
     public function fromLink(Link $linkDefinition)
     {
+        $this->getEventManager()->trigger(__FUNCTION__ . '.pre', $this, ['linkDefinition' => $linkDefinition]);
+
         $linkExtractor = $this->linkCollectionExtractor->getLinkExtractor();
 
         return $linkExtractor->extract($linkDefinition);


### PR DESCRIPTION
When working with hierarchical resources, like e.g.:

```/api/parent/:parent_id/child[/:child_id]```

the call to `fromLink()` in the `RestController::create()` fails to generate the URL because it doesn't have the `parent_id`. My first idea was to inject it into `$halEntity` using one of the existing events like `create.pre` or `create.post`, but the first one fires too early and the latter fires too late.

The problem is, that I can't modify the `$halEntity` generated here:
```https://github.com/zfcampus/zf-rest/blob/master/src/RestController.php#L396```
before it goes to the call of `fromLink()` here:
```https://github.com/zfcampus/zf-rest/blob/master/src/RestController.php#L401```

This PR adds a trigger for a pre-event in the `fromLink()` method, so that we can hook into this method to modify the Hal entity before the URL is generated.